### PR TITLE
Archver s6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
 
 # add s6 overlay
  curl -o \
-	/tmp/s6-overlay.tar.gz -L \
+ /tmp/s6-overlay.tar.gz -L \
 	"${OVERLAY_WWW}" && \
  tar xvfz /tmp/s6-overlay.tar.gz -C / && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM gliderlabs/alpine:3.4
 MAINTAINER sparklyballs
 
 # set version for s6 overlay
-ARG OVERLAY_VERSION="v1.18.1.0"
+ARG OVERLAY_VERSION="v1.18.1.3"
+ARG OVERLAY_ARCH="amd64"
+ARG OVERLAY_URL="https://github.com/just-containers/s6-overlay/releases/download"
+ARG OVERLAY_WWW="${OVERLAY_URL}"/"${OVERLAY_VERSION}"/s6-overlay-"${OVERLAY_ARCH}".tar.gz
 
 # set some environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)$ " \
@@ -17,8 +20,6 @@ RUN \
 
  apk add --no-cache \
 	bash \
-	s6 \
-	s6-portable-utils \
 	tzdata && \
 
 apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
@@ -27,8 +28,8 @@ apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
 # add s6 overlay
  curl -o \
 	/tmp/s6-overlay.tar.gz -L \
-	https://github.com/just-containers/s6-overlay/releases/download/"${OVERLAY_VERSION}"/s6-overlay-nobin.tar.gz && \
-	tar xvfz /tmp/s6-overlay.tar.gz -C / && \
+	"${OVERLAY_WWW}" && \
+ tar xvfz /tmp/s6-overlay.tar.gz -C / && \
 
 # clean up
  apk del --purge \


### PR DESCRIPTION
Drop using nobin version of S6 and then installing packages.....
Use arch specific overlay, set by variable, easier tranistion to armhf and smaller build.
