### PR TITLE
force using busybox id app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,15 @@ ARG OVERLAY_ARCH="amd64"
 
 # environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)$ " \
+PATH="/usr/local/bin:$PATH" \
 HOME="/root" \
 TERM="xterm"
 
-# install packages
+# copy busybox id to /usr/local/bin, coreutils (gnu) version of id, bug with group ids.
 RUN \
+ cp /usr/bin/id /usr/local/bin/id && \
+
+# install packages
  apk add --no-cache --virtual=build-dependencies \
 	curl \
 	tar && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ issue with coreutils (gnu) version of id app reporting incorrect group id if group exists
+ 1st idea for fix is copying busybox version to /usr/local/bin and editing PATH to use it over the coreutils version.

+ fixes linuxserver/docker-beets#16 
+ fixes linuxserver/docker-deluge#14