### PR TITLE
always setting uid and gid rather than test

### DIFF
--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -1,11 +1,10 @@
 #!/usr/bin/with-contenv bash
 
+[[ -z $PGID ]] && PGID="911"
+[[ -z $PUID ]] && PUID="911"
 
-PUID=${PUID:-911}
-PGID=${PGID:-911}
-
-if [ ! "$(id -u abc)" -eq "$PUID" ]; then usermod -o -u "$PUID" abc ; fi
-if [ ! "$(id -g abc)" -eq "$PGID" ]; then groupmod -o -g "$PGID" abc ; fi
+groupmod -o -g "$PGID" abc
+usermod -o -u "$PUID" abc
 
 echo "
 -------------------------------------

--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
-[[ -z $PGID ]] && PGID="911"
-[[ -z $PUID ]] && PUID="911"
+PUID=${PUID:-911}
+PGID=${PGID:-911}
 
 groupmod -o -g "$PGID" abc
 usermod -o -u "$PUID" abc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ id reports incorrect group id
+ 2nd idea for fix is always setting group id and user id rather than testing against id output.

+ fixes linuxserver/docker-beets#16 
+ fixes linuxserver/docker-deluge#14
