### PR TITLE
Support adding user to more groups

### DIFF
--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -2,9 +2,14 @@
 
 PUID=${PUID:-911}
 PGID=${PGID:-911}
+PGIDS=${PGIDS}
 
 groupmod -o -g "$PGID" abc
 usermod -o -u "$PUID" abc
+for TMP_GID in $PGIDS; do
+    groupadd -o -g $TMP_GID "g$TMP_GID"
+    usermod -a -G "g$TMP_GID" abc
+done
 
 echo "
 -------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

This change will add `-e PGIDS="1002 1003"` to allow the user to be added to more groups.

I needed this for my sickrage, couchpotato and transmission setup because I use different groups for
tvshows, movies and downloads etc.

The groups will be created with the names g1002, g1003 in the container where the name of the group
doesn't really matter.
