### PR TITLE
Update PS1 so that root's shell shows #

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG OVERLAY_VERSION="v1.21.4.0"
 ARG OVERLAY_ARCH="amd64"
 
 # environment variables
-ENV PS1="$(whoami)@$(hostname):$(pwd)$ " \
+ENV PS1="$(whoami)@$(hostname):$(pwd)\$ " \
 HOME="/root" \
 TERM="xterm"
 


### PR DESCRIPTION
Correct PS1 character based on user 
```
root@709c4a324838:/#
```
Instead of
```
root@709c4a324838:/$
```