### PR TITLE
removing ability to build base images on x86 and ripping out single qemu layer

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -36,8 +36,6 @@ RUN \
 # Runtime stage
 FROM scratch
 COPY --from=rootfs-stage /root-out/ /
-# Add qemu to run on x86_64 systems
-COPY qemu-aarch64-static /usr/bin
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL MAINTAINER="sparkyballs,TheLamer"
 
@@ -76,6 +74,11 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ echo "**** add qemu ****" && \
+ curl -o \
+ /usr/bin/qemu-aarch64-static -L \
+	"https://lsio-ci.ams3.digitaloceanspaces.com/qemu-aarch64-static" && \
+ chmod +x /usr/bin/qemu-aarch64-static && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -36,8 +36,6 @@ RUN \
 # Runtime stage
 FROM scratch
 COPY --from=rootfs-stage /root-out/ /
-# Add qemu to build on x86_64 systems
-COPY qemu-arm-static /usr/bin
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL MAINTAINER="sparkyballs,TheLamer"
 
@@ -76,6 +74,11 @@ RUN \
 	/app \
 	/config \
 	/defaults && \
+ echo "**** add qemu ****" && \
+ curl -o \
+ /usr/bin/qemu-arm-static -L \
+        "https://lsio-ci.ams3.digitaloceanspaces.com/qemu-arm-static" && \
+ chmod +x /usr/bin/qemu-arm-static && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \


### PR DESCRIPTION
Reference https://github.com/linuxserver/docker-jenkins-builder/pull/21

This drops the ability to build these images on x86, but if you are playing with the base images you should know how to workaround. Rips a layer out and removes the download from our build logic. 