### PR TITLE
inital logic to load env files from a specific identifier FILE__

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine:3.10 as rootfs-stage
-MAINTAINER sparkyballs,thelamer
 
 # environment
 ENV REL=v3.10
@@ -40,7 +39,7 @@ COPY --from=rootfs-stage /root-out/ /
 ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL MAINTAINER="sparkyballs,TheLamer"
+LABEL maintainer="TheLamer"
 
 # set version for s6 overlay
 ARG OVERLAY_VERSION="v1.22.1.0"

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,5 +1,4 @@
 FROM alpine:3.10 as rootfs-stage
-MAINTAINER sparkyballs,thelamer
 
 # environment
 ENV REL=v3.10
@@ -40,7 +39,7 @@ COPY --from=rootfs-stage /root-out/ /
 ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL MAINTAINER="sparkyballs,TheLamer"
+LABEL maintainer="TheLamer"
 
 # set version for s6 overlay
 ARG OVERLAY_VERSION="v1.22.1.0"

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,5 +1,4 @@
 FROM alpine:3.10 as rootfs-stage
-MAINTAINER sparkyballs,thelamer
 
 # environment
 ENV REL=v3.10
@@ -40,7 +39,7 @@ COPY --from=rootfs-stage /root-out/ /
 ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL MAINTAINER="sparkyballs,TheLamer"
+LABEL maintainer="TheLamer"
 
 # set version for s6 overlay
 ARG OVERLAY_VERSION="v1.22.1.0"

--- a/root/etc/cont-init.d/01-envfile
+++ b/root/etc/cont-init.d/01-envfile
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+if [[ "$(ls /var/run/s6/container_environment/ | xargs)" == *"FILE__"* ]]; then
+  for FILENAME in /var/run/s6/container_environment/*; do
+    if [[ "${FILENAME##*/}" == "FILE__"* ]]; then
+      SECRETFILE=$(cat ${FILENAME})
+      if [[ -f ${SECRETFILE} ]]; then
+        FILESTRIP=${FILENAME//FILE__/}
+        cat ${SECRETFILE} > ${FILESTRIP}
+        echo "[env-init] ${FILESTRIP##*/} set from ${FILENAME##*/}"
+      else
+        echo "[env-init] cannot find secret in ${FILENAME##*/}"
+      fi
+    fi
+  done
+fi


### PR DESCRIPTION
Up for discussion to coincide with the monthly at the end of November. 

Any ENV variable that starts with `FILE__` will set the env variable after that string IE `FILE__PGID` based off of the file contents of the file defined in it. (literally just cat it in) 

This logic would also be applied to our Ubuntu base if approved. 

I tried to be as unobtrusive as possible first checking for a string in a blob of env vars before even looping and running. This running from bash is not a typo it does not need env vars. 

This is a result of the discussion here : 

https://github.com/linuxserver/docker-mariadb/issues/35