### PR TITLE
Include app donate info

### DIFF
--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -16,7 +16,14 @@ echo '
 
 
 Brought to you by linuxserver.io
-We gratefully accept donations at:
+-------------------------------------'
+if [[ -f /donate.txt ]]; then
+    echo '
+To support the app dev(s) visit:'
+    cat /donate.txt
+fi
+echo '
+To support LSIO projects visit:
 https://www.linuxserver.io/donate/
 -------------------------------------
 GID/UID


### PR DESCRIPTION
Wording is adjusted for LSIO donate link.

Contents of `/donate.txt` are displayed in the console if the file exists. This file is meant to contain a link to donate to the app (upstream) and added to the `root` folder in the repos of our containers. Ex: https://github.com/linuxserver/docker-nextcloud/tree/master/root