### PR TITLE
Update s6-overlay to v2.0.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="TheLamer"
 
 # set version for s6 overlay
-ARG OVERLAY_VERSION="v1.22.1.0"
+ARG OVERLAY_VERSION="v2.0.0.1"
 ARG OVERLAY_ARCH="amd64"
 
 # environment variables

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -42,7 +42,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="TheLamer"
 
 # set version for s6 overlay
-ARG OVERLAY_VERSION="v1.22.1.0"
+ARG OVERLAY_VERSION="v2.0.0.1"
 ARG OVERLAY_ARCH="aarch64"
 
 # environment variables

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -42,7 +42,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="TheLamer"
 
 # set version for s6 overlay
-ARG OVERLAY_VERSION="v1.22.1.0"
+ARG OVERLAY_VERSION="v2.0.0.1"
 ARG OVERLAY_ARCH="arm"
 
 # environment variables


### PR DESCRIPTION
https://github.com/just-containers/s6-overlay/releases/tag/v2.0.0.1
https://github.com/just-containers/s6-overlay#upgrade-notes
https://github.com/just-containers/s6-overlay/compare/v1.22.1.0...v2.0.0.1