### PR TITLE
WIP: Add riscv64 support

### DIFF
--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,7 +1,7 @@
 FROM alpine:edge as rootfs-stage
 
 # environment
-ENV REL=v3.15
+ENV REL=edge
 ENV ARCH=riscv64
 ENV MIRROR=http://dl-cdn.alpinelinux.org/alpine
 ENV PACKAGES=alpine-baselayout,\

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,0 +1,96 @@
+FROM alpine:edge as rootfs-stage
+
+# environment
+ENV REL=v3.15
+ENV ARCH=riscv64
+ENV MIRROR=http://dl-cdn.alpinelinux.org/alpine
+ENV PACKAGES=alpine-baselayout,\
+alpine-keys,\
+apk-tools,\
+busybox,\
+libc-utils,\
+xz
+
+# install packages
+RUN \
+ apk add --no-cache \
+	bash \
+	curl \
+	tzdata \
+	xz
+
+# fetch builder script from gliderlabs
+RUN \
+ curl -o \
+ /mkimage-alpine.bash -L \
+	https://raw.githubusercontent.com/gliderlabs/docker-alpine/master/builder/scripts/mkimage-alpine.bash && \
+ chmod +x \
+	/mkimage-alpine.bash && \
+ ./mkimage-alpine.bash  && \
+ mkdir /root-out && \
+ tar xf \
+	/rootfs.tar.xz -C \
+	/root-out && \
+ sed -i -e 's/^root::/root:!:/' /root-out/etc/shadow
+
+# Runtime stage
+FROM scratch
+COPY --from=rootfs-stage /root-out/ /
+ARG BUILD_DATE
+ARG VERSION
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+LABEL maintainer="TheLamer"
+
+# set version for s6 overlay
+ARG OVERLAY_VERSION="v2.2.0.3"
+ARG OVERLAY_ARCH="riscv64"
+
+# add s6 overlay
+ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+COPY patch/ /tmp/patch
+
+# environment variables
+ENV PS1="$(whoami)@$(hostname):$(pwd)\\$ " \
+HOME="/root" \
+TERM="xterm"
+
+RUN \
+ echo "**** install build packages ****" && \
+ apk add --no-cache --virtual=build-dependencies \
+	curl \
+	patch \
+	tar && \
+ echo "**** install runtime packages ****" && \
+ apk add --no-cache \
+	bash \
+	ca-certificates \
+	coreutils \
+	procps \
+	shadow \
+	tzdata && \
+ echo "**** create abc user and make our folders ****" && \
+ groupmod -g 1000 users && \
+ useradd -u 911 -U -d /config -s /bin/false abc && \
+ usermod -G users abc && \
+ mkdir -p \
+	/app \
+	/config \
+	/defaults && \
+ mv /usr/bin/with-contenv /usr/bin/with-contenvb && \
+ patch -u /etc/s6/init/init-stage2 -i /tmp/patch/etc/s6/init/init-stage2.patch && \
+ echo "**** add qemu ****" && \
+ curl -o \
+ /usr/bin/qemu-riscv64-static -L \
+	"https://lsio-ci.ams3.digitaloceanspaces.com/qemu-riscv64-static" && \
+ chmod +x /usr/bin/qemu-riscv64-static && \
+ echo "**** cleanup ****" && \
+ apk del --purge \
+	build-dependencies && \
+ rm -rf \
+	/tmp/*
+
+# add local files
+COPY root/ /
+
+ENTRYPOINT ["/init"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

I suggest to build a linux/riscv64 compatible docker image.

## Benefits of this PR and context:

The riscv64 architecture is an open standard instruction set architecture (ISA), which is slowly gaining traction.

The introduction of a new architecture poses a chicken-egg situation, where the hardware wont work without any software, and the software wont exist without the hardware.

As to allow this architecture to grow, and as to allow projects depending on this image to support riscv, I propose to build docker images for this architecture.

## How Has This Been Tested?

This PR depends on the s6-overlay library from just-containers.

The following PR should, if approved and released, allow building this image on riscv64.

`docker build -t riscv64-test -f Dockerfile.riscv64 .`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:

The Dockerfile is based on the aarch64/armhrf Dockerfiles with minimal adjustments.

The s6-overlay PR is this one: https://github.com/just-containers/s6-overlay/pull/366

Note that docker alpine does not yet provide any standard versioned release, thus the usage of the `edge` tag.
https://github.com/alpinelinux/docker-alpine/issues/218
