### PR TITLE
add retry to mod curls

### DIFF
--- a/root/docker-mods
+++ b/root/docker-mods
@@ -27,14 +27,14 @@ fi
 # Use different filtering depending on URL
 get_blob_sha () {
   if [[ $1 == "ghcr" ]]; then
-    curl \
+    curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
       --silent \
       --location \
       --request GET \
       --header "Authorization: Bearer $2" \
       $3 | jq -r '.layers[0].digest'
   else
-    curl \
+    curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
       --silent \
       --location \
       --request GET \
@@ -94,7 +94,7 @@ for DOCKER_MOD in "${DOCKER_MODS[@]}"; do
   echo "[mod-init] Applying ${DOCKER_MOD} files to container"
   # Get Dockerhub token for api operations
   TOKEN=\
-"$(curl \
+"$(curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
     --silent \
     --header 'GET' \
     "${AUTH_URL}" \
@@ -107,13 +107,15 @@ for DOCKER_MOD in "${DOCKER_MODS[@]}"; do
     echo "[mod-init] ${DOCKER_MOD} at ${SHALAYER} has been previously applied skipping"
   else
     # Download and extract layer to /
-    curl \
+    curl -f --retry 10 --retry-max-time 60 --retry-all-errors \
       --silent \
       --location \
       --request GET \
       --header "Authorization: Bearer ${TOKEN}" \
-      "${BLOB_URL}${SHALAYER}" \
-      | tar xz -C /
+      "${BLOB_URL}${SHALAYER}" -o \
+      /modtarball.tar.xz
+    tar xzf /modtarball.tar.xz -C /
+    rm -rf /modtarball.tar.xz
     echo ${SHALAYER} > "/${FILENAME}"
   fi
 done


### PR DESCRIPTION
If a bunch of containers using mods are created and started by compose at the same time, some of the curl operations fail for various reasons (due to hammering ghcr at the same time). Failed curls result in silent errors in the logs and prevent the mods from being installed.

This PR adds retries to the curl operations and seems to alleviate the issues based on local tests (9 containers with 1 mod each, created and started at the same time).

Untar operation of the mod image layer is moved to a 3 step process of writing to a file, untarring and deleting the file rather than piping curl output to tar, as the retry process may output unwanted extra info to tar, resulting in a broken tar operation. But curl output to file removes the file before a retry, preventing broken tarballs.