### PR TITLE
Fix shellcheck, shfmt, and logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,6 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
 
-[{**.sh,root/etc/cont-init.d/**,root/etc/services.d/**}]
+[{**.sh,root/docker-mods,root/etc/s6-overlay/s6-rc.d/**,root/etc/cont-init.d/**,root/etc/services.d/**}]
 indent_style = space
 indent_size = 4

--- a/root/docker-mods
+++ b/root/docker-mods
@@ -1,28 +1,29 @@
 #!/usr/bin/with-contenv bash
 
-#shellcheck disable=SC2120
-
 # Set executable bit on cont-init and services built into the image
-set_legacy_executable_bits () {
+set_legacy_executable_bits() {
   mkdir -p /etc/{cont-init.d,services.d}
   chmod +x \
     /etc/cont-init.d/* \
-    /etc/services.d/*/* 2> /dev/null || true
+    /etc/services.d/*/* 2>/dev/null || true
 }
 
 # Tamper check legacy custom service locations
-tamper_check () {
-  if ([ -d "/config/custom-services.d" ] && [ -n "$(find /config/custom-services.d ! -user root)" ]); then
-      echo "**** Potential tampering with custom scripts detected ****"
-      randstr=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-8};echo;)
-      mv "/config/custom-services.d" "/config/custom-services.d.${randstr}"
-      echo "**** Folder /config/custom-services.d is moved to /config/custom-services.d.${randstr} ****"
-      echo "**** The folder '/config/custom-services.d' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
-      mkdir -p /config/custom-services.d
-      chown 0:0 /config/custom-services.d
-  elif ([ -d "/config/custom-services.d" ] && [ -n "$(find /config/custom-services.d -perm -o+w)" ]); then
-      echo "**** The folder '/config/custom-services.d' or some of its contents have write permissions for others, which is a security risk. ****"
-      echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+tamper_check() {
+  if [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d ! -user root)" ]]; then
+    echo "**** Potential tampering with custom scripts detected ****"
+    randstr=$(
+      tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c8
+      echo
+    )
+    mv "/config/custom-services.d" "/config/custom-services.d.${randstr}"
+    echo "**** Folder /config/custom-services.d is moved to /config/custom-services.d.${randstr} ****"
+    echo "**** The folder '/config/custom-services.d' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
+    mkdir -p /config/custom-services.d
+    chown 0:0 /config/custom-services.d
+  elif [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d -perm -o+w)" ]]; then
+    echo "**** The folder '/config/custom-services.d' or some of its contents have write permissions for others, which is a security risk. ****"
+    echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
   fi
 }
 
@@ -33,72 +34,68 @@ process_custom_services() {
 
   # Remove all existing custom services before continuing to ensure
   # we aren't running anything the user may have removed
-  if [ -n "$(/bin/ls -A /etc/s6-overlay/s6-rc.d/custom-svc-* 2>/dev/null)" ]; then
-      echo "[custom-init] removing existing custom services..."
-      rm -rf /etc/s6-overlay/s6-rc.d/custom-svc-*
+  if [[ -n "$(/bin/ls -A /etc/s6-overlay/s6-rc.d/custom-svc-* 2>/dev/null)" ]]; then
+    echo "[custom-init] removing existing custom services..."
+    rm -rf /etc/s6-overlay/s6-rc.d/custom-svc-*
   fi
 
-  if { [ -z "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]; } && \
-      { [ -z "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]; }; then    
-      echo "[custom-init] no custom services found, skipping..."
-      return
+  if [[ -z "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]] &&
+    [[ -z "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]]; then
+    echo "[custom-init] no custom services found, skipping..."
+    return
   fi
 
   # Make sure custom service directory exists and has files in it
-  if { [ -e "${SERVICES_DIR}" ] && [ -n "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]; }; then
-      if [ -n "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]; then
-        echo "[custom-init] service files found in ${SERVICES_DIR}"
-        for SERVICE in ${SERVICES_DIR}/*; do
-          NAME="$(basename "${SERVICE}")"
-          if [ -f "${SERVICE}" ]; then
-            echo "[custom-init] ${NAME}: service detected, copying..."
-            mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
-            cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-            chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-            echo "longrun" > /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
-            touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
-            touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
-            echo "[custom-init] ${NAME}: copied"
-          elif [ ! -f "${SERVICE}" ]; then
-            echo "[custom-init] ${NAME}: is not a file"
-          fi
-        done
+  if [[ -e "${SERVICES_DIR}" ]] && [[ -n "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]]; then
+    echo "[custom-init] service files found in ${SERVICES_DIR}"
+    for SERVICE in "${SERVICES_DIR}"/*; do
+      NAME="$(basename "${SERVICE}")"
+      if [[ -f "${SERVICE}" ]]; then
+        echo "[custom-init] ${NAME}: service detected, copying..."
+        mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
+        cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+        chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+        echo "longrun" >/etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
+        touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
+        touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
+        echo "[custom-init] ${NAME}: copied"
+      elif [[ ! -f "${SERVICE}" ]]; then
+        echo "[custom-init] ${NAME}: is not a file"
       fi
+    done
   fi
 
-  if { [ -e "${SERVICES_DIR_OLD}" ] && [ -n "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]; }; then
-      if [ -n "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]; then
-        echo "[custom-init] service files found in ${SERVICES_DIR_OLD}"
-        for SERVICE in ${SERVICES_DIR_OLD}/*; do
-          NAME="$(basename "${SERVICE}")"
-          if [ -f "${SERVICE}" ]; then
-            echo "[custom-init] ${NAME}: service detected, copying..."
-            mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
-            cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-            chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-            echo "longrun" > /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
-            touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
-            touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
-            echo "[custom-init] ${NAME}: copied"
-          elif [ ! -f "${SERVICE}" ]; then
-            echo "[custom-init] ${NAME}: is not a file"
-          fi
-        done
-      fi 
+  if [[ -e "${SERVICES_DIR_OLD}" ]] && [[ -n "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]]; then
+    echo "[custom-init] service files found in ${SERVICES_DIR_OLD}"
+    for SERVICE in "${SERVICES_DIR_OLD}"/*; do
+      NAME="$(basename "${SERVICE}")"
+      if [[ -f "${SERVICE}" ]]; then
+        echo "[custom-init] ${NAME}: service detected, copying..."
+        mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
+        cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+        chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+        echo "longrun" >/etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
+        touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
+        touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
+        echo "[custom-init] ${NAME}: copied"
+      elif [[ ! -f "${SERVICE}" ]]; then
+        echo "[custom-init] ${NAME}: is not a file"
+      fi
+    done
   fi
 }
 
 # Check for curl
-curl_check () {
-  if [ ! -f /usr/bin/curl ] || [ ! -f /usr/bin/jq ]; then
+curl_check() {
+  if [[ ! -f /usr/bin/curl ]] || [[ ! -f /usr/bin/jq ]]; then
     echo "[mod-init] Curl/JQ was not found on this system for Docker mods installing"
-    if [ -f /usr/bin/apt ]; then
+    if [[ -f /usr/bin/apt ]]; then
       ## Ubuntu
       apt-get update
       apt-get install --no-install-recommends -y \
         curl \
         jq
-    elif [ -f /sbin/apk ]; then
+    elif [[ -f /sbin/apk ]]; then
       # Alpine
       apk add --no-cache \
         curl \
@@ -108,30 +105,28 @@ curl_check () {
 }
 
 # Use different filtering depending on URL
-get_blob_sha () {
+get_blob_sha() {
   if [[ $1 == "ghcr" ]]; then
     curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
       --silent \
       --location \
       --request GET \
       --header "Authorization: Bearer $2" \
-      $3 | jq -r '.layers[0].digest'
+      "$3" | jq -r '.layers[0].digest'
   else
     curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
       --silent \
       --location \
       --request GET \
       --header "Authorization: Bearer $2" \
-      $3 | jq -r '.fsLayers[0].blobSum'
+      "$3" | jq -r '.fsLayers[0].blobSum'
   fi
 }
 
 # Main run logic
-run_mods () {
+run_mods() {
   echo "[mod-init] Attempting to run Docker Modification Logic"
-  IFS='|'
-  DOCKER_MODS=(${DOCKER_MODS})
-  for DOCKER_MOD in "${DOCKER_MODS[@]}"; do
+  while IFS="|" read -r DOCKER_MOD; do
     # Support alternative endpoints
     if [[ ${DOCKER_MOD} == ghcr.io/* ]] || [[ ${DOCKER_MOD} == linuxserver/* ]]; then
       DOCKER_MOD="${DOCKER_MOD#ghcr.io/*}"
@@ -162,31 +157,29 @@ run_mods () {
       MODE="dockerhub"
     fi
     # Kill off modification logic if any of the usernames are banned
-    BLACKLIST=$(curl -s https://raw.githubusercontent.com/linuxserver/docker-mods/master/blacklist.txt)
-    IFS=$'\n'
-    BLACKLIST=(${BLACKLIST})
-    for BANNED in "${BLACKLIST[@]}"; do
-      if [ "${BANNED}" == "${USERNAME,,}" ]; then
-        if [ -z ${RUN_BANNED_MODS+x} ]; then
+    while IFS= read -r BANNED; do
+      if [[ "${BANNED,,}" == "${USERNAME,,}" ]]; then
+        if [[ -z ${RUN_BANNED_MODS+x} ]]; then
           echo "[mod-init] ${DOCKER_MOD} is banned from use due to reported abuse aborting mod logic"
           return
         else
           echo "[mod-init] You have chosen to run banned mods ${DOCKER_MOD} will be applied"
         fi
       fi
-    done
+    done < <(curl -s https://raw.githubusercontent.com/linuxserver/docker-mods/master/blacklist.txt)
     echo "[mod-init] Applying ${DOCKER_MOD} files to container"
     # Get Dockerhub token for api operations
-    TOKEN="$(curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
-      --silent \
-      --header 'GET' \
-      "${AUTH_URL}" \
-      | jq -r '.token' \
+    TOKEN="$(
+      curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
+        --silent \
+        --header 'GET' \
+        "${AUTH_URL}" |
+        jq -r '.token'
     )"
     # Determine first and only layer of image
     SHALAYER=$(get_blob_sha "${MODE}" "${TOKEN}" "${MANIFEST_URL}")
     # Check if we have allready applied this layer
-    if [ -f "/${FILENAME}" ] && [ "${SHALAYER}" == "$(cat /${FILENAME})" ]; then
+    if [[ -f "/${FILENAME}" ]] && [[ "${SHALAYER}" == "$(cat /"${FILENAME}")" ]]; then
       echo "[mod-init] ${DOCKER_MOD} at ${SHALAYER} has been previously applied skipping"
     else
       # Download and extract layer to /
@@ -199,11 +192,11 @@ run_mods () {
         /modtarball.tar.xz
       mkdir -p /tmp/mod
       tar xzf /modtarball.tar.xz -C /tmp/mod
-      if [ -d /tmp/mod/etc/s6-overlay ]; then
-        if [ -d /tmp/mod/etc/cont-init.d ]; then
+      if [[ -d /tmp/mod/etc/s6-overlay ]]; then
+        if [[ -d /tmp/mod/etc/cont-init.d ]]; then
           rm -rf /tmp/mod/etc/cont-init.d
         fi
-        if [ -d /tmp/mod/etc/services.d ]; then
+        if [[ -d /tmp/mod/etc/services.d ]]; then
           rm -rf /tmp/mod/etc/services.d
         fi
       fi
@@ -212,10 +205,10 @@ run_mods () {
       shopt -u dotglob
       rm -rf /tmp/mod
       rm -rf /modtarball.tar.xz
-      echo ${SHALAYER} > "/${FILENAME}"
+      echo "${SHALAYER}" >"/${FILENAME}"
       echo "[mod-init] ${DOCKER_MOD} applied to container"
     fi
-  done
+  done <<<"${DOCKER_MODS}"
 }
 
 # Tamper check legacy services
@@ -225,9 +218,9 @@ tamper_check
 process_custom_services
 
 # Run mod logic
-if [ -n "${DOCKER_MODS+x}" ]; then
-    curl_check
-    run_mods
+if [[ -n "${DOCKER_MODS+x}" ]]; then
+  curl_check
+  run_mods
 fi
 
 # Set executable bit on legacy cont-init and services built into the image and anything legacy unpacked by mods

--- a/root/docker-mods
+++ b/root/docker-mods
@@ -9,21 +9,31 @@ set_legacy_executable_bits() {
         /etc/services.d/*/* 2>/dev/null || true
 }
 
-# Tamper check legacy custom service locations
+# Tamper check custom service locations
 tamper_check() {
-    if [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d ! -user root)" ]]; then
+    SERVICES_DIR_OLD="/config/custom-services.d"
+    SERVICES_DIR="/custom-services.d"  
+    if [[ -d "${SERVICES_DIR_OLD}" ]] && [[ -n "$(find ${SERVICES_DIR_OLD} ! -user root)" ]]; then
         echo "**** Potential tampering with custom scripts detected ****"
         randstr=$(
             tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c8
             echo
         )
-        mv "/config/custom-services.d" "/config/custom-services.d.${randstr}"
-        echo "**** Folder /config/custom-services.d is moved to /config/custom-services.d.${randstr} ****"
-        echo "**** The folder '/config/custom-services.d' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
-        mkdir -p /config/custom-services.d
-        chown 0:0 /config/custom-services.d
-    elif [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d -perm -o+w)" ]]; then
-        echo "**** The folder '/config/custom-services.d' or some of its contents have write permissions for others, which is a security risk. ****"
+        mv "${SERVICES_DIR_OLD}" "${SERVICES_DIR_OLD}.${randstr}"
+        echo "**** Folder ${SERVICES_DIR_OLD} is moved to ${SERVICES_DIR_OLD}.${randstr} ****"
+        echo "**** The folder '${SERVICES_DIR_OLD}' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
+        mkdir -p ${SERVICES_DIR_OLD}
+        chown 0:0 ${SERVICES_DIR_OLD}
+    elif [[ -d "${SERVICES_DIR_OLD}" ]] && [[ -n "$(find ${SERVICES_DIR_OLD} -perm -o+w)" ]]; then
+        echo "**** The folder '${SERVICES_DIR_OLD}' or some of its contents have write permissions for others, which is a security risk. ****"
+        echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+    fi
+
+    if [[ -d "${SERVICES_DIR}" ]] && [[ -n "$(find ${SERVICES_DIR} ! -user root)" ]]; then
+        echo "**** The folder '${SERVICES_DIR}' or some of its contents are not owned by root, which is a security risk. ****"
+        echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+    elif [[ -d "${SERVICES_DIR}" ]] && [[ -n "$(find ${SERVICES_DIR} -perm -o+w)" ]]; then
+        echo "**** The folder '${SERVICES_DIR}' or some of its contents have write permissions for others, which is a security risk. ****"
         echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
     fi
 }

--- a/root/docker-mods
+++ b/root/docker-mods
@@ -1,214 +1,215 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 # Set executable bit on cont-init and services built into the image
 set_legacy_executable_bits() {
-  mkdir -p /etc/{cont-init.d,services.d}
-  chmod +x \
-    /etc/cont-init.d/* \
-    /etc/services.d/*/* 2>/dev/null || true
+    mkdir -p /etc/{cont-init.d,services.d}
+    chmod +x \
+        /etc/cont-init.d/* \
+        /etc/services.d/*/* 2>/dev/null || true
 }
 
 # Tamper check legacy custom service locations
 tamper_check() {
-  if [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d ! -user root)" ]]; then
-    echo "**** Potential tampering with custom scripts detected ****"
-    randstr=$(
-      tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c8
-      echo
-    )
-    mv "/config/custom-services.d" "/config/custom-services.d.${randstr}"
-    echo "**** Folder /config/custom-services.d is moved to /config/custom-services.d.${randstr} ****"
-    echo "**** The folder '/config/custom-services.d' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
-    mkdir -p /config/custom-services.d
-    chown 0:0 /config/custom-services.d
-  elif [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d -perm -o+w)" ]]; then
-    echo "**** The folder '/config/custom-services.d' or some of its contents have write permissions for others, which is a security risk. ****"
-    echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
-  fi
+    if [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d ! -user root)" ]]; then
+        echo "**** Potential tampering with custom scripts detected ****"
+        randstr=$(
+            tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c8
+            echo
+        )
+        mv "/config/custom-services.d" "/config/custom-services.d.${randstr}"
+        echo "**** Folder /config/custom-services.d is moved to /config/custom-services.d.${randstr} ****"
+        echo "**** The folder '/config/custom-services.d' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
+        mkdir -p /config/custom-services.d
+        chown 0:0 /config/custom-services.d
+    elif [[ -d "/config/custom-services.d" ]] && [[ -n "$(find /config/custom-services.d -perm -o+w)" ]]; then
+        echo "**** The folder '/config/custom-services.d' or some of its contents have write permissions for others, which is a security risk. ****"
+        echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+    fi
 }
 
 # Process Custom Services
 process_custom_services() {
-  SERVICES_DIR_OLD="/config/custom-services.d"
-  SERVICES_DIR="/custom-services.d"
+    SERVICES_DIR_OLD="/config/custom-services.d"
+    SERVICES_DIR="/custom-services.d"
 
-  # Remove all existing custom services before continuing to ensure
-  # we aren't running anything the user may have removed
-  if [[ -n "$(/bin/ls -A /etc/s6-overlay/s6-rc.d/custom-svc-* 2>/dev/null)" ]]; then
-    echo "[custom-init] removing existing custom services..."
-    rm -rf /etc/s6-overlay/s6-rc.d/custom-svc-*
-  fi
+    # Remove all existing custom services before continuing to ensure
+    # we aren't running anything the user may have removed
+    if [[ -n "$(/bin/ls -A /etc/s6-overlay/s6-rc.d/custom-svc-* 2>/dev/null)" ]]; then
+        echo "[custom-init] removing existing custom services..."
+        rm -rf /etc/s6-overlay/s6-rc.d/custom-svc-*
+    fi
 
-  if [[ -z "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]] &&
-    [[ -z "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]]; then
-    echo "[custom-init] no custom services found, skipping..."
-    return
-  fi
+    if [[ -z "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]] &&
+        [[ -z "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]]; then
+        echo "[custom-init] no custom services found, skipping..."
+        return
+    fi
 
-  # Make sure custom service directory exists and has files in it
-  if [[ -e "${SERVICES_DIR}" ]] && [[ -n "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]]; then
-    echo "[custom-init] service files found in ${SERVICES_DIR}"
-    for SERVICE in "${SERVICES_DIR}"/*; do
-      NAME="$(basename "${SERVICE}")"
-      if [[ -f "${SERVICE}" ]]; then
-        echo "[custom-init] ${NAME}: service detected, copying..."
-        mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
-        cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-        chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-        echo "longrun" >/etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
-        touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
-        touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
-        echo "[custom-init] ${NAME}: copied"
-      elif [[ ! -f "${SERVICE}" ]]; then
-        echo "[custom-init] ${NAME}: is not a file"
-      fi
-    done
-  fi
+    # Make sure custom service directory exists and has files in it
+    if [[ -e "${SERVICES_DIR}" ]] && [[ -n "$(/bin/ls -A ${SERVICES_DIR} 2>/dev/null)" ]]; then
+        echo "[custom-init] service files found in ${SERVICES_DIR}"
+        for SERVICE in "${SERVICES_DIR}"/*; do
+            NAME="$(basename "${SERVICE}")"
+            if [[ -f "${SERVICE}" ]]; then
+                echo "[custom-init] ${NAME}: service detected, copying..."
+                mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
+                cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+                chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+                echo "longrun" >/etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
+                touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
+                touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
+                echo "[custom-init] ${NAME}: copied"
+            elif [[ ! -f "${SERVICE}" ]]; then
+                echo "[custom-init] ${NAME}: is not a file"
+            fi
+        done
+    fi
 
-  if [[ -e "${SERVICES_DIR_OLD}" ]] && [[ -n "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]]; then
-    echo "[custom-init] service files found in ${SERVICES_DIR_OLD}"
-    for SERVICE in "${SERVICES_DIR_OLD}"/*; do
-      NAME="$(basename "${SERVICE}")"
-      if [[ -f "${SERVICE}" ]]; then
-        echo "[custom-init] ${NAME}: service detected, copying..."
-        mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
-        cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-        chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
-        echo "longrun" >/etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
-        touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
-        touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
-        echo "[custom-init] ${NAME}: copied"
-      elif [[ ! -f "${SERVICE}" ]]; then
-        echo "[custom-init] ${NAME}: is not a file"
-      fi
-    done
-  fi
+    if [[ -e "${SERVICES_DIR_OLD}" ]] && [[ -n "$(/bin/ls -A ${SERVICES_DIR_OLD} 2>/dev/null)" ]]; then
+        echo "[custom-init] service files found in ${SERVICES_DIR_OLD}"
+        for SERVICE in "${SERVICES_DIR_OLD}"/*; do
+            NAME="$(basename "${SERVICE}")"
+            if [[ -f "${SERVICE}" ]]; then
+                echo "[custom-init] ${NAME}: service detected, copying..."
+                mkdir -p /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/
+                cp "${SERVICE}" /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+                chmod +x /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/run
+                echo "longrun" >/etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/type
+                touch /etc/s6-overlay/s6-rc.d/custom-svc-"${NAME}"/dependencies.d/init-services
+                touch /etc/s6-overlay/s6-rc.d/init-mods-end/dependencies.d/custom-svc-"${NAME}"
+                echo "[custom-init] ${NAME}: copied"
+            elif [[ ! -f "${SERVICE}" ]]; then
+                echo "[custom-init] ${NAME}: is not a file"
+            fi
+        done
+    fi
 }
 
 # Check for curl
 curl_check() {
-  if [[ ! -f /usr/bin/curl ]] || [[ ! -f /usr/bin/jq ]]; then
-    echo "[mod-init] Curl/JQ was not found on this system for Docker mods installing"
-    if [[ -f /usr/bin/apt ]]; then
-      ## Ubuntu
-      apt-get update
-      apt-get install --no-install-recommends -y \
-        curl \
-        jq
-    elif [[ -f /sbin/apk ]]; then
-      # Alpine
-      apk add --no-cache \
-        curl \
-        jq
+    if [[ ! -f /usr/bin/curl ]] || [[ ! -f /usr/bin/jq ]]; then
+        echo "[mod-init] Curl/JQ was not found on this system for Docker mods installing"
+        if [[ -f /usr/bin/apt ]]; then
+            ## Ubuntu
+            apt-get update
+            apt-get install --no-install-recommends -y \
+                curl \
+                jq
+        elif [[ -f /sbin/apk ]]; then
+            # Alpine
+            apk add --no-cache \
+                curl \
+                jq
+        fi
     fi
-  fi
 }
 
 # Use different filtering depending on URL
 get_blob_sha() {
-  if [[ $1 == "ghcr" ]]; then
-    curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
-      --silent \
-      --location \
-      --request GET \
-      --header "Authorization: Bearer $2" \
-      "$3" | jq -r '.layers[0].digest'
-  else
-    curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
-      --silent \
-      --location \
-      --request GET \
-      --header "Authorization: Bearer $2" \
-      "$3" | jq -r '.fsLayers[0].blobSum'
-  fi
+    if [[ $1 == "ghcr" ]]; then
+        curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
+            --silent \
+            --location \
+            --request GET \
+            --header "Authorization: Bearer $2" \
+            "$3" | jq -r '.layers[0].digest'
+    else
+        curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
+            --silent \
+            --location \
+            --request GET \
+            --header "Authorization: Bearer $2" \
+            "$3" | jq -r '.fsLayers[0].blobSum'
+    fi
 }
 
 # Main run logic
 run_mods() {
-  echo "[mod-init] Attempting to run Docker Modification Logic"
-  while IFS="|" read -r DOCKER_MOD; do
-    # Support alternative endpoints
-    if [[ ${DOCKER_MOD} == ghcr.io/* ]] || [[ ${DOCKER_MOD} == linuxserver/* ]]; then
-      DOCKER_MOD="${DOCKER_MOD#ghcr.io/*}"
-      ENDPOINT="${DOCKER_MOD%%:*}"
-      USERNAME="${DOCKER_MOD%%/*}"
-      REPO="${ENDPOINT#*/}"
-      TAG="${DOCKER_MOD#*:}"
-      if [[ ${TAG} == "${DOCKER_MOD}" ]]; then
-        TAG="latest"
-      fi
-      FILENAME="${USERNAME}.${REPO}.${TAG}"
-      AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull"
-      MANIFEST_URL="https://ghcr.io/v2/${ENDPOINT}/manifests/${TAG}"
-      BLOB_URL="https://ghcr.io/v2/${ENDPOINT}/blobs/"
-      MODE="ghcr"
-    else
-      ENDPOINT="${DOCKER_MOD%%:*}"
-      USERNAME="${DOCKER_MOD%%/*}"
-      REPO="${ENDPOINT#*/}"
-      TAG="${DOCKER_MOD#*:}"
-      if [[ ${TAG} == "${DOCKER_MOD}" ]]; then
-        TAG="latest"
-      fi
-      FILENAME="${USERNAME}.${REPO}.${TAG}"
-      AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${ENDPOINT}:pull"
-      MANIFEST_URL="https://registry-1.docker.io/v2/${ENDPOINT}/manifests/${TAG}"
-      BLOB_URL="https://registry-1.docker.io/v2/${ENDPOINT}/blobs/"
-      MODE="dockerhub"
-    fi
-    # Kill off modification logic if any of the usernames are banned
-    while IFS= read -r BANNED; do
-      if [[ "${BANNED,,}" == "${USERNAME,,}" ]]; then
-        if [[ -z ${RUN_BANNED_MODS+x} ]]; then
-          echo "[mod-init] ${DOCKER_MOD} is banned from use due to reported abuse aborting mod logic"
-          return
+    echo "[mod-init] Attempting to run Docker Modification Logic"
+    for DOCKER_MOD in $(echo "${DOCKER_MODS}" | tr '|' '\n'); do
+        # Support alternative endpoints
+        if [[ ${DOCKER_MOD} == ghcr.io/* ]] || [[ ${DOCKER_MOD} == linuxserver/* ]]; then
+            DOCKER_MOD="${DOCKER_MOD#ghcr.io/*}"
+            ENDPOINT="${DOCKER_MOD%%:*}"
+            USERNAME="${DOCKER_MOD%%/*}"
+            REPO="${ENDPOINT#*/}"
+            TAG="${DOCKER_MOD#*:}"
+            if [[ ${TAG} == "${DOCKER_MOD}" ]]; then
+                TAG="latest"
+            fi
+            FILENAME="${USERNAME}.${REPO}.${TAG}"
+            AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull"
+            MANIFEST_URL="https://ghcr.io/v2/${ENDPOINT}/manifests/${TAG}"
+            BLOB_URL="https://ghcr.io/v2/${ENDPOINT}/blobs/"
+            MODE="ghcr"
         else
-          echo "[mod-init] You have chosen to run banned mods ${DOCKER_MOD} will be applied"
+            ENDPOINT="${DOCKER_MOD%%:*}"
+            USERNAME="${DOCKER_MOD%%/*}"
+            REPO="${ENDPOINT#*/}"
+            TAG="${DOCKER_MOD#*:}"
+            if [[ ${TAG} == "${DOCKER_MOD}" ]]; then
+                TAG="latest"
+            fi
+            FILENAME="${USERNAME}.${REPO}.${TAG}"
+            AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${ENDPOINT}:pull"
+            MANIFEST_URL="https://registry-1.docker.io/v2/${ENDPOINT}/manifests/${TAG}"
+            BLOB_URL="https://registry-1.docker.io/v2/${ENDPOINT}/blobs/"
+            MODE="dockerhub"
         fi
-      fi
-    done < <(curl -s https://raw.githubusercontent.com/linuxserver/docker-mods/master/blacklist.txt)
-    echo "[mod-init] Applying ${DOCKER_MOD} files to container"
-    # Get Dockerhub token for api operations
-    TOKEN="$(
-      curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
-        --silent \
-        --header 'GET' \
-        "${AUTH_URL}" |
-        jq -r '.token'
-    )"
-    # Determine first and only layer of image
-    SHALAYER=$(get_blob_sha "${MODE}" "${TOKEN}" "${MANIFEST_URL}")
-    # Check if we have allready applied this layer
-    if [[ -f "/${FILENAME}" ]] && [[ "${SHALAYER}" == "$(cat /"${FILENAME}")" ]]; then
-      echo "[mod-init] ${DOCKER_MOD} at ${SHALAYER} has been previously applied skipping"
-    else
-      # Download and extract layer to /
-      curl -f --retry 10 --retry-max-time 60 --retry-all-errors \
-        --silent \
-        --location \
-        --request GET \
-        --header "Authorization: Bearer ${TOKEN}" \
-        "${BLOB_URL}${SHALAYER}" -o \
-        /modtarball.tar.xz
-      mkdir -p /tmp/mod
-      tar xzf /modtarball.tar.xz -C /tmp/mod
-      if [[ -d /tmp/mod/etc/s6-overlay ]]; then
-        if [[ -d /tmp/mod/etc/cont-init.d ]]; then
-          rm -rf /tmp/mod/etc/cont-init.d
+        # Kill off modification logic if any of the usernames are banned
+        for BANNED in $(curl -s https://raw.githubusercontent.com/linuxserver/docker-mods/master/blacklist.txt); do
+            if [[ "${BANNED,,}" == "${USERNAME,,}" ]]; then
+                if [[ -z ${RUN_BANNED_MODS+x} ]]; then
+                    echo "[mod-init] ${DOCKER_MOD} is banned from use due to reported abuse aborting mod logic"
+                    return
+                else
+                    echo "[mod-init] You have chosen to run banned mods ${DOCKER_MOD} will be applied"
+                fi
+            fi
+        done
+        echo "[mod-init] Applying ${DOCKER_MOD} files to container"
+        # Get Dockerhub token for api operations
+        TOKEN="$(
+            curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
+                --silent \
+                --header 'GET' \
+                "${AUTH_URL}" |
+                jq -r '.token'
+        )"
+        # Determine first and only layer of image
+        SHALAYER=$(get_blob_sha "${MODE}" "${TOKEN}" "${MANIFEST_URL}")
+        # Check if we have allready applied this layer
+        if [[ -f "/${FILENAME}" ]] && [[ "${SHALAYER}" == "$(cat /"${FILENAME}")" ]]; then
+            echo "[mod-init] ${DOCKER_MOD} at ${SHALAYER} has been previously applied skipping"
+        else
+            # Download and extract layer to /
+            curl -f --retry 10 --retry-max-time 60 --retry-all-errors \
+                --silent \
+                --location \
+                --request GET \
+                --header "Authorization: Bearer ${TOKEN}" \
+                "${BLOB_URL}${SHALAYER}" -o \
+                /modtarball.tar.xz
+            mkdir -p /tmp/mod
+            tar xzf /modtarball.tar.xz -C /tmp/mod
+            if [[ -d /tmp/mod/etc/s6-overlay ]]; then
+                if [[ -d /tmp/mod/etc/cont-init.d ]]; then
+                    rm -rf /tmp/mod/etc/cont-init.d
+                fi
+                if [[ -d /tmp/mod/etc/services.d ]]; then
+                    rm -rf /tmp/mod/etc/services.d
+                fi
+            fi
+            shopt -s dotglob
+            cp -R /tmp/mod/* /
+            shopt -u dotglob
+            rm -rf /tmp/mod
+            rm -rf /modtarball.tar.xz
+            echo "${SHALAYER}" >"/${FILENAME}"
+            echo "[mod-init] ${DOCKER_MOD} applied to container"
         fi
-        if [[ -d /tmp/mod/etc/services.d ]]; then
-          rm -rf /tmp/mod/etc/services.d
-        fi
-      fi
-      shopt -s dotglob
-      cp -R /tmp/mod/* /
-      shopt -u dotglob
-      rm -rf /tmp/mod
-      rm -rf /modtarball.tar.xz
-      echo "${SHALAYER}" >"/${FILENAME}"
-      echo "[mod-init] ${DOCKER_MOD} applied to container"
-    fi
-  done <<<"${DOCKER_MODS}"
+    done
 }
 
 # Tamper check legacy services
@@ -219,8 +220,8 @@ process_custom_services
 
 # Run mod logic
 if [[ -n "${DOCKER_MODS+x}" ]]; then
-  curl_check
-  run_mods
+    curl_check
+    run_mods
 fi
 
 # Set executable bit on legacy cont-init and services built into the image and anything legacy unpacked by mods

--- a/root/etc/s6-overlay/s6-rc.d/init-adduser/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-adduser/run
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 PUID=${PUID:-911}
 PGID=${PGID:-911}
@@ -37,7 +38,7 @@ User gid:    $(id -g abc)
 time32="$(date +%Y)"
 
 if [[ "${time32}" == "1970" || "${time32}" == "1969" ]] && [ "$(uname -m)" == "armv7l" ]; then
-  echo '
+    echo '
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 Your DockerHost is running an outdated version of libseccomp
@@ -48,7 +49,7 @@ Apps will not behave correctly without this
 
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 '
-sleep infinity
+    sleep infinity
 fi
 
 chown abc:abc /app

--- a/root/etc/s6-overlay/s6-rc.d/init-custom-files/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-custom-files/run
@@ -7,6 +7,23 @@ SCRIPTS_DIR="/custom-cont-init.d"
 
 SERVICES_DIR_OLD="/config/custom-services.d"
 
+# Tamper check legacy custom script locations
+if [[ -d "${SCRIPTS_DIR_OLD}" ]] && [[ -n "$(find ${SCRIPTS_DIR_OLD} ! -user root)" ]]; then
+    echo "**** Potential tampering with custom scripts detected ****"
+    randstr=$(
+        tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c8
+        echo
+    )
+    mv "${SCRIPTS_DIR_OLD}" "${SCRIPTS_DIR_OLD}.${randstr}"
+    echo "**** Folder ${SCRIPTS_DIR_OLD} is moved to ${SCRIPTS_DIR_OLD}.${randstr} ****"
+    echo "**** The folder '${SCRIPTS_DIR_OLD}' and its contents need to all be owned by root to prevent root escalation inside the container!!! ****"
+    mkdir -p ${SCRIPTS_DIR_OLD}
+    chown 0:0 ${SCRIPTS_DIR_OLD}
+elif [[ -d "${SCRIPTS_DIR_OLD}" ]] && [[ -n "$(find ${SCRIPTS_DIR_OLD} -perm -o+w)" ]]; then
+    echo "**** The folder '${SCRIPTS_DIR_OLD}' or some of its contents have write permissions for others, which is a security risk. ****"
+    echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+fi
+
 # chown legacy folders if they exist
 if [[ -e "${SCRIPTS_DIR_OLD}" ]]; then
     chown -R 0:0 "${SCRIPTS_DIR_OLD}"

--- a/root/etc/s6-overlay/s6-rc.d/init-custom-files/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-custom-files/run
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 # Directories
 SCRIPTS_DIR_OLD="/config/custom-cont-init.d"
@@ -7,50 +8,46 @@ SCRIPTS_DIR="/custom-cont-init.d"
 SERVICES_DIR_OLD="/config/custom-services.d"
 
 # chown legacy folders if they exist
-if [ -e "${SCRIPTS_DIR_OLD}" ]; then
+if [[ -e "${SCRIPTS_DIR_OLD}" ]]; then
     chown -R 0:0 "${SCRIPTS_DIR_OLD}"
 fi
 
 # chown legacy folders if they exist
-if [ -e "${SERVICES_DIR_OLD}" ]; then
+if [[ -e "${SERVICES_DIR_OLD}" ]]; then
     chown -R 0:0 "${SERVICES_DIR_OLD}"
 fi
 
-if { [ -z "$(/bin/ls -A ${SCRIPTS_DIR} 2>/dev/null)" ]; } && \
-    { [ -z "$(/bin/ls -A ${SCRIPTS_DIR_OLD} 2>/dev/null)" ]; }; then    
+if [[ -z "$(/bin/ls -A ${SCRIPTS_DIR} 2>/dev/null)" ]] &&
+    [[ -z "$(/bin/ls -A ${SCRIPTS_DIR_OLD} 2>/dev/null)" ]]; then
     echo "[custom-init] no custom files found, skipping..."
     exit 0
 fi
 
 # Make sure custom init directory exists and has files in it
-if { [ -e "${SCRIPTS_DIR}" ] && [ -n "$(/bin/ls -A ${SCRIPTS_DIR} 2>/dev/null)" ]; }; then
-    if [ -n "$(/bin/ls -A ${SCRIPTS_DIR} 2>/dev/null)" ]; then
-      echo "[custom-init] files found, executing"
-      for SCRIPT in ${SCRIPTS_DIR}/*; do
+if [[ -e "${SCRIPTS_DIR}" ]] && [[ -n "$(/bin/ls -A ${SCRIPTS_DIR} 2>/dev/null)" ]]; then
+    echo "[custom-init] files found, executing"
+    for SCRIPT in "${SCRIPTS_DIR}"/*; do
         NAME="$(basename "${SCRIPT}")"
-        if [ -f "${SCRIPT}" ]; then
-          echo "[custom-init] ${NAME}: executing..."
-          /bin/bash "${SCRIPT}"
-          echo "[custom-init] ${NAME}: exited $?"
-        elif [ ! -f "${SCRIPT}" ]; then
-          echo "[custom-init] ${NAME}: is not a file"
+        if [[ -f "${SCRIPT}" ]]; then
+            echo "[custom-init] ${NAME}: executing..."
+            /bin/bash "${SCRIPT}"
+            echo "[custom-init] ${NAME}: exited $?"
+        elif [[ ! -f "${SCRIPT}" ]]; then
+            echo "[custom-init] ${NAME}: is not a file"
         fi
-      done
-    fi
+    done
 fi
 
-if { [ -e "${SCRIPTS_DIR_OLD}" ] && [ -n "$(/bin/ls -A ${SCRIPTS_DIR_OLD} 2>/dev/null)" ]; }; then
-    if [ -n "$(/bin/ls -A ${SCRIPTS_DIR_OLD} 2>/dev/null)" ]; then
-      echo "[custom-init] files found, executing"
-      for SCRIPT in ${SCRIPTS_DIR_OLD}/*; do
+if [[ -e "${SCRIPTS_DIR_OLD}" ]] && [[ -n "$(/bin/ls -A ${SCRIPTS_DIR_OLD} 2>/dev/null)" ]]; then
+    echo "[custom-init] files found, executing"
+    for SCRIPT in "${SCRIPTS_DIR_OLD}"/*; do
         NAME="$(basename "${SCRIPT}")"
-        if [ -f "${SCRIPT}" ]; then
-          echo "[custom-init] ${NAME}: executing..."
-          /bin/bash "${SCRIPT}"
-          echo "[custom-init] ${NAME}: exited $?"
-        elif [ ! -f "${SCRIPT}" ]; then
-          echo "[custom-init] ${NAME}: is not a file"
+        if [[ -f "${SCRIPT}" ]]; then
+            echo "[custom-init] ${NAME}: executing..."
+            /bin/bash "${SCRIPT}"
+            echo "[custom-init] ${NAME}: exited $?"
+        elif [[ ! -f "${SCRIPT}" ]]; then
+            echo "[custom-init] ${NAME}: is not a file"
         fi
-      done
-    fi
+    done
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-custom-files/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-custom-files/run
@@ -7,7 +7,7 @@ SCRIPTS_DIR="/custom-cont-init.d"
 
 SERVICES_DIR_OLD="/config/custom-services.d"
 
-# Tamper check legacy custom script locations
+# Tamper check custom script locations
 if [[ -d "${SCRIPTS_DIR_OLD}" ]] && [[ -n "$(find ${SCRIPTS_DIR_OLD} ! -user root)" ]]; then
     echo "**** Potential tampering with custom scripts detected ****"
     randstr=$(
@@ -21,6 +21,14 @@ if [[ -d "${SCRIPTS_DIR_OLD}" ]] && [[ -n "$(find ${SCRIPTS_DIR_OLD} ! -user roo
     chown 0:0 ${SCRIPTS_DIR_OLD}
 elif [[ -d "${SCRIPTS_DIR_OLD}" ]] && [[ -n "$(find ${SCRIPTS_DIR_OLD} -perm -o+w)" ]]; then
     echo "**** The folder '${SCRIPTS_DIR_OLD}' or some of its contents have write permissions for others, which is a security risk. ****"
+    echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+fi
+
+if [[ -d "${SCRIPTS_DIR}" ]] && [[ -n "$(find ${SCRIPTS_DIR} ! -user root)" ]]; then
+    echo "**** The folder '${SCRIPTS_DIR}' or some of its contents are not owned by root, which is a security risk. ****"
+    echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
+elif [[ -d "${SCRIPTS_DIR}" ]] && [[ -n "$(find ${SCRIPTS_DIR} -perm -o+w)" ]]; then
+    echo "**** The folder '${SCRIPTS_DIR}' or some of its contents have write permissions for others, which is a security risk. ****"
     echo "**** Please review the permissions of this folder and its contents to make sure they are owned by root, and can only be modified by root. ****"
 fi
 

--- a/root/etc/s6-overlay/s6-rc.d/init-envfile/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-envfile/run
@@ -1,16 +1,17 @@
-#! /bin/bash
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-if [[ "$(ls /var/run/s6/container_environment/ | xargs)" == *"FILE__"* ]]; then
-  for FILENAME in /var/run/s6/container_environment/*; do
-    if [[ "${FILENAME##*/}" == "FILE__"* ]]; then
-      SECRETFILE=$(cat ${FILENAME})
-      if [[ -f ${SECRETFILE} ]]; then
-        FILESTRIP=${FILENAME//FILE__/}
-        cat ${SECRETFILE} > ${FILESTRIP}
-        echo "[env-init] ${FILESTRIP##*/} set from ${FILENAME##*/}"
-      else
-        echo "[env-init] cannot find secret in ${FILENAME##*/}"
-      fi
-    fi
-  done
+if [[ "$(find /var/run/s6/container_environment/ -maxdepth 1 -print0 | xargs)" == *"FILE__"* ]]; then
+    for FILENAME in /var/run/s6/container_environment/*; do
+        if [[ "${FILENAME##*/}" == "FILE__"* ]]; then
+            SECRETFILE=$(cat "${FILENAME}")
+            if [[ -f ${SECRETFILE} ]]; then
+                FILESTRIP=${FILENAME//FILE__/}
+                cat "${SECRETFILE}" >"${FILESTRIP}"
+                echo "[env-init] ${FILESTRIP##*/} set from ${FILENAME##*/}"
+            else
+                echo "[env-init] cannot find secret in ${FILENAME##*/}"
+            fi
+        fi
+    done
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-migrations/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-migrations/run
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 MIGRATIONS_DIR="/migrations"
 MIGRATIONS_HISTORY="/config/.migrations"
@@ -6,25 +7,28 @@ MIGRATIONS_HISTORY="/config/.migrations"
 echo "[migrations] started"
 
 if [[ ! -d ${MIGRATIONS_DIR} ]]; then
-  echo "[migrations] no migrations found"
-  exit
+    echo "[migrations] no migrations found"
+    exit
 fi
 
 for MIGRATION in $(find ${MIGRATIONS_DIR}/* | sort -n); do
-  NAME="$(basename "${MIGRATION}")"
-  if [[ -f ${MIGRATIONS_HISTORY} ]] && grep -Fxq "${NAME}" ${MIGRATIONS_HISTORY}; then
-    echo "[migrations] ${NAME}: skipped"
-    continue
-  fi
-  echo "[migrations] ${NAME}: executing..."
-  chmod +x "${MIGRATION}"
-  EXIT_CODE=$(/bin/bash "${MIGRATION}"; echo $?)
-  if [[ ${EXIT_CODE} -ne 0 ]]; then
-    echo "[migrations] ${NAME}: failed with exit code ${EXIT_CODE}, contact support"
-    exit "${EXIT_CODE}"
-  fi
-  echo "${NAME}" >> ${MIGRATIONS_HISTORY}
-  echo "[migrations] ${NAME}: succeeded"
+    NAME="$(basename "${MIGRATION}")"
+    if [[ -f ${MIGRATIONS_HISTORY} ]] && grep -Fxq "${NAME}" ${MIGRATIONS_HISTORY}; then
+        echo "[migrations] ${NAME}: skipped"
+        continue
+    fi
+    echo "[migrations] ${NAME}: executing..."
+    chmod +x "${MIGRATION}"
+    EXIT_CODE=$(
+        /bin/bash "${MIGRATION}"
+        echo $?
+    )
+    if [[ ${EXIT_CODE} -ne 0 ]]; then
+        echo "[migrations] ${NAME}: failed with exit code ${EXIT_CODE}, contact support"
+        exit "${EXIT_CODE}"
+    fi
+    echo "${NAME}" >>${MIGRATIONS_HISTORY}
+    echo "[migrations] ${NAME}: succeeded"
 done
 
 echo "[migrations] done"

--- a/root/etc/s6-overlay/s6-rc.d/init-mods-package-install/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mods-package-install/run
@@ -1,33 +1,34 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-if [ -f "/mod-repo-packages-to-install.list" ]; then
+if [[ -f "/mod-repo-packages-to-install.list" ]]; then
     echo "**** Installing all mod packages ****"
-    if [ -f /usr/bin/apt ]; then
+    if [[ -f /usr/bin/apt ]]; then
         export DEBIAN_FRONTEND="noninteractive"
         apt-get update
         apt-get install -y --no-install-recommends \
-            $(cat /mod-repo-packages-to-install.list)
-    elif [ -f /sbin/apk ]; then
+            "$(cat /mod-repo-packages-to-install.list)"
+    elif [[ -f /sbin/apk ]]; then
         apk add --no-cache \
-            $(cat /mod-repo-packages-to-install.list)
+            "$(cat /mod-repo-packages-to-install.list)"
     fi
 fi
 
-if [ -f "/mod-pip-packages-to-install.list" ]; then
+if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     echo "**** Installing all pip packages ****"
     python3 -m pip install -U pip wheel setuptools
-    if [ -f /usr/bin/apt ]; then
+    if [[ -f /usr/bin/apt ]]; then
         PIP_ARGS="-f https://wheel-index.linuxserver.io/ubuntu/"
-    elif [ -f /sbin/apk ]; then
+    elif [[ -f /sbin/apk ]]; then
         ALPINE_VER=$(grep main /etc/apk/repositories | sed 's|.*alpine/v||' | sed 's|/main.*||')
-        if [ "${ALPINE_VER}" = "3.14" ]; then
+        if [[ "${ALPINE_VER}" = "3.14" ]]; then
             PIP_ARGS="-f https://wheel-index.linuxserver.io/alpine/"
         else
             PIP_ARGS="-f https://wheel-index.linuxserver.io/alpine-${ALPINE_VER}/"
         fi
     fi
-    python3 -m pip install ${PIP_ARGS} \
-        $(cat /mod-pip-packages-to-install.list)
+    python3 -m pip install "${PIP_ARGS}" \
+        "$(cat /mod-pip-packages-to-install.list)"
 fi
 
 rm -rf \

--- a/root/etc/s6-overlay/s6-rc.d/init-script-check/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-script-check/run
@@ -1,12 +1,13 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 # This doesn't do anything yet
 
 exit 0
 
-if { [ -n "$(/bin/ls -A "/config/custom-cont-init.d" 2>/dev/null)" ]; } && \
-    { [ -n "$(/bin/ls -A "/config/custom-services.d" 2>/dev/null)" ]; }; then    
-cat <<-EOF | tee /config/custom-cont-init.d/README.txt,/config/custom-services.d/README.txt 2>/dev/null
+if [[ -n "$(/bin/ls -A "/config/custom-cont-init.d" 2>/dev/null)" ]] &&
+    [[ -n "$(/bin/ls -A "/config/custom-services.d" 2>/dev/null)" ]]; then
+    cat <<-EOF | tee /config/custom-cont-init.d/README.txt,/config/custom-services.d/README.txt 2>/dev/null
     ********************************************************
     ********************************************************
     *                                                      *

--- a/root/etc/s6-overlay/s6-rc.d/init-script-check/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-script-check/run
@@ -1,10 +1,6 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# This doesn't do anything yet
-
-exit 0
-
 if [[ -n "$(/bin/ls -A "/config/custom-cont-init.d" 2>/dev/null)" ]] &&
     [[ -n "$(/bin/ls -A "/config/custom-services.d" 2>/dev/null)" ]]; then
     cat <<-EOF | tee /config/custom-cont-init.d/README.txt,/config/custom-services.d/README.txt 2>/dev/null

--- a/root/usr/bin/with-contenv
+++ b/root/usr/bin/with-contenv
@@ -1,9 +1,9 @@
-#! /bin/bash
+#!/bin/bash
 
-if [[ -f /var/run/s6/container_environment/UMASK ]] && \
-    { [[ "$(pwdx $$)" =~ "/run/s6/legacy-services/" ]] || \
-    [[ "$(pwdx $$)" =~ "/run/s6/services/" ]] || \
-    [[ "$(pwdx $$)" =~ "/servicedirs/svc-" ]]; }; then
-    umask $(cat /var/run/s6/container_environment/UMASK)
+if [[ -f /var/run/s6/container_environment/UMASK ]] &&
+    { [[ "$(pwdx $$)" =~ "/run/s6/legacy-services/" ]] ||
+        [[ "$(pwdx $$)" =~ "/run/s6/services/" ]] ||
+        [[ "$(pwdx $$)" =~ "/servicedirs/svc-" ]]; }; then
+    umask "$(cat /var/run/s6/container_environment/UMASK)"
 fi
 exec /command/with-contenv "$@"


### PR DESCRIPTION
These changes will also be needed in https://github.com/linuxserver/docker-baseimage-alpine/pull/103

- fixed the shellcheck issues, mostly quoting variables
- got rid of the parameter use on the tamper check urandom function (it was always 8)
- found a few places where an if statement was nested inside an identical if statement
- found some syntax where `if { conditions }; then` was used and switched them to `if conditions; then`
- used bash's double square braces with all conditions instead of sh's single square braces
- fixed shellcheck complaining about array expansion by switching 
```shell
IFS='|'
DOCKER_MODS=(${DOCKER_MODS})
for DOCKER_MOD in "${DOCKER_MODS[@]}"; do
```
to
```shell
for DOCKER_MOD in $(echo "${DOCKER_MODS}" | tr '|' '\n'); do
```
(also similar for the banned array logic)