### PR TITLE
Warn about newlines in secrets (3.18)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-envfile/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-envfile/run
@@ -6,7 +6,7 @@ if find /run/s6/container_environment/FILE__* -maxdepth 1 > /dev/null 2>&1; then
             SECRETFILE=$(cat "${FILENAME}")
             if [[ -f ${SECRETFILE} ]]; then
                 FILESTRIP=${FILENAME//FILE__/}
-                if [[ $(tail -n1 "${SECRETFILE}" | wc -l) = 1 ]]; then
+                if [[ $(tail -n1 "${SECRETFILE}" | wc -l) != 0 ]]; then
                     echo "[env-init] Your secret: ${FILENAME##*/}"
                     echo "           contains a trailing newline and may not work as expected"
                 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-envfile/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-envfile/run
@@ -6,11 +6,11 @@ if find /run/s6/container_environment/FILE__* -maxdepth 1 > /dev/null 2>&1; then
             SECRETFILE=$(cat "${FILENAME}")
             if [[ -f ${SECRETFILE} ]]; then
                 FILESTRIP=${FILENAME//FILE__/}
-                if [[ ${SECRET_NO_SANITIZE,,} = "true" ]]; then
-                    cat "${SECRETFILE}" >"${FILESTRIP}"
-                else
-                    tr -d '\n' < "${SECRETFILE}" >"${FILESTRIP}"
+                if [[ $(tail -n1 "${SECRETFILE}" | wc -l) = 1 ]]; then
+                    echo "[env-init] Your secret: ${FILENAME##*/}"
+                    echo "           contains a trailing newline and may not work as expected"
                 fi
+                cat "${SECRETFILE}" >"${FILESTRIP}"
                 echo "[env-init] ${FILESTRIP##*/} set from ${FILENAME##*/}"
             else
                 echo "[env-init] cannot find secret in ${FILENAME##*/}"

--- a/root/etc/s6-overlay/s6-rc.d/init-envfile/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-envfile/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 
 if find /run/s6/container_environment/FILE__* -maxdepth 1 > /dev/null 2>&1; then
-    for FILENAME in /run/s6/container_environment/*; do
+    for FILENAME in /run/s6/container_environment/FILE__*; do
             SECRETFILE=$(cat "${FILENAME}")
             if [[ -f ${SECRETFILE} ]]; then
                 FILESTRIP=${FILENAME//FILE__/}

--- a/root/etc/s6-overlay/s6-rc.d/init-envfile/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-envfile/run
@@ -7,7 +7,11 @@ if find /run/s6/container_environment/*"FILE__"* -maxdepth 1 > /dev/null 2>&1; t
             SECRETFILE=$(cat "${FILENAME}")
             if [[ -f ${SECRETFILE} ]]; then
                 FILESTRIP=${FILENAME//FILE__/}
-                cat "${SECRETFILE}" >"${FILESTRIP}"
+                if [[ ${SECRET_NO_SANITIZE,,} = "true" ]]; then
+                    cat "${SECRETFILE}" >"${FILESTRIP}"
+                else
+                    tr -d '\n' < "${SECRETFILE}" >"${FILESTRIP}"
+                fi
                 echo "[env-init] ${FILESTRIP##*/} set from ${FILENAME##*/}"
             else
                 echo "[env-init] cannot find secret in ${FILENAME##*/}"

--- a/root/etc/s6-overlay/s6-rc.d/init-envfile/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-envfile/run
@@ -1,9 +1,8 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-if find /run/s6/container_environment/*"FILE__"* -maxdepth 1 > /dev/null 2>&1; then
+if find /run/s6/container_environment/FILE__* -maxdepth 1 > /dev/null 2>&1; then
     for FILENAME in /run/s6/container_environment/*; do
-        if [[ "${FILENAME##*/}" == "FILE__"* ]]; then
             SECRETFILE=$(cat "${FILENAME}")
             if [[ -f ${SECRETFILE} ]]; then
                 FILESTRIP=${FILENAME//FILE__/}
@@ -16,6 +15,5 @@ if find /run/s6/container_environment/*"FILE__"* -maxdepth 1 > /dev/null 2>&1; t
             else
                 echo "[env-init] cannot find secret in ${FILENAME##*/}"
             fi
-        fi
     done
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This is an attempt to deal with the dozens of people who create secrets with errant newlines. By default it will remove any newline characters from secrets before assigning to them envs. There is an undocumented bypass for the 3 people who will inevitably have some horrible edge case where they're legitimately using multi-line envs in secrets.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
