### PR TITLE
RO support hooks (edge)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3 as rootfs-stage
+FROM alpine:3 AS rootfs-stage
 
 # environment
 ENV ROOTFS=/root-out

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,9 @@ ARG LSIOWN_VERSION="v1"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
-ADD --chmod=744 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
-ADD --chmod=744 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
-ADD --chmod=744 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
+ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
+ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
+ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
 
 # environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)\\$ " \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -56,9 +56,9 @@ ARG LSIOWN_VERSION="v1"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
-ADD --chmod=744 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
-ADD --chmod=744 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
-ADD --chmod=744 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
+ADD --chmod=745 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
+ADD --chmod=745 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
+ADD --chmod=745 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
 
 # environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)\\$ " \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3 as rootfs-stage
+FROM alpine:3 AS rootfs-stage
 
 # environment
 ENV ROOTFS=/root-out

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -56,9 +56,9 @@ ARG LSIOWN_VERSION="v1"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="TheLamer"
 
-ADD --chmod=745 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
-ADD --chmod=745 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
-ADD --chmod=745 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
+ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
+ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
+ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
 
 # environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)\\$ " \

--- a/root/etc/s6-overlay/s6-rc.d/init-adduser/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-adduser/run
@@ -7,7 +7,9 @@ PGID=${PGID:-911}
 if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     groupmod -o -g "$PGID" abc
     usermod -o -u "$PUID" abc
+fi
 
+if { [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; } || [[ ! ${LSIO_FIRST_PARTY} = "true" ]]; then
     cat /etc/s6-overlay/s6-rc.d/init-adduser/branding
 else
     cat /run/branding

--- a/root/etc/s6-overlay/s6-rc.d/init-adduser/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-adduser/run
@@ -4,10 +4,14 @@
 PUID=${PUID:-911}
 PGID=${PGID:-911}
 
-groupmod -o -g "$PGID" abc
-usermod -o -u "$PUID" abc
+if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
+    groupmod -o -g "$PGID" abc
+    usermod -o -u "$PUID" abc
 
-cat /etc/s6-overlay/s6-rc.d/init-adduser/branding
+    cat /etc/s6-overlay/s6-rc.d/init-adduser/branding
+else
+    cat /run/branding
+fi
 
 if [[ -f /donate.txt ]]; then
     echo '
@@ -21,10 +25,17 @@ https://www.linuxserver.io/donate/
 ───────────────────────────────────────
 GID/UID
 ───────────────────────────────────────'
+if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
 echo "
 User UID:    $(id -u abc)
 User GID:    $(id -g abc)
 ───────────────────────────────────────"
+else
+echo "
+User UID:    $(stat /run -c %u)
+User GID:    $(stat /run -c %g)
+───────────────────────────────────────"
+fi
 if [[ -f /build_version ]]; then
     cat /build_version
     echo '
@@ -32,6 +43,8 @@ if [[ -f /build_version ]]; then
     '
 fi
 
-lsiown abc:abc /app
-lsiown abc:abc /config
-lsiown abc:abc /defaults
+if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
+    lsiown abc:abc /app
+    lsiown abc:abc /config
+    lsiown abc:abc /defaults
+fi

--- a/root/etc/s6-overlay/s6-rc.d/init-crontab-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-crontab-config/run
@@ -2,9 +2,11 @@
 # shellcheck shell=bash
 
 for cron_user in abc root; do
-    if [[ -f "/etc/crontabs/${cron_user}" ]]; then
-        lsiown "${cron_user}":"${cron_user}" "/etc/crontabs/${cron_user}"
-        crontab -u "${cron_user}" "/etc/crontabs/${cron_user}"
+    if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
+        if [[ -f "/etc/crontabs/${cron_user}" ]]; then
+            lsiown "${cron_user}":"${cron_user}" "/etc/crontabs/${cron_user}"
+            crontab -u "${cron_user}" "/etc/crontabs/${cron_user}"
+        fi
     fi
 
     if [[ -f "/defaults/crontabs/${cron_user}" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
These are a set of core changes required to support read-only operation with some downstream images. It also lays the groundwork for potential support of --user with s6 3.2. Also requires some changes to the docker-mods (see https://github.com/linuxserver/docker-mods/commit/72c376dd44456bdfe6a4b2346731978c62eee05e), both can be merged independently without breaking anything.

If testing, /run needs to be mounted to tmpfs with exec

Needs:
- https://github.com/linuxserver/docker-mods/pull/917

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
