### PR TITLE
Dockerfiles: reuse build arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,70 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.20 AS rootfs-stage
+## Build arguments provided via cli arguments
+ARG VERSION
+ARG BUILD_DATE
 
-# environment
-ENV ROOTFS=/root-out
-ENV REL=v3.21
-ENV ARCH=x86_64
-ENV MIRROR=http://dl-cdn.alpinelinux.org/alpine
-ENV PACKAGES=alpine-baselayout,\
+## Runtime stage defaults
+# Labels
+ARG RUNTIME_LABEL_BUILD_VERSION="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+ARG RUNTIME_LABEL_MAINTAINER="TheLamer"
+# User: root
+ARG RUNTIME_ROOT_HOME="/root"
+ARG RUNTIME_ROOT_TERM="xterm"
+# User: abc
+ARG RUNTIME_ABC_HOME=/config
+ARG RUNTIME_ABC_SHELL=/bin/false
+ARG RUNTIME_ABC_GROUP=users
+ARG RUNTIME_ABC_GID=1000
+ARG RUNTIME_ABC_UID=911
+# Shell prompt
+ARG RUNTIME_PS1="$(whoami)@$(hostname):$(pwd)\\$ "
+# s6 overlay
+ARG RUNTIME_S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0"
+ARG RUNTIME_S6_VERBOSITY=1
+ARG RUNTIME_S6_STAGE2_HOOK=/docker-mods
+# Virtual environment location of lsiopy
+ARG RUNTIME_VIRTUAL_ENV=/lsiopy
+# mod-scripts URL
+ARG RUNTIME_MOD_SCRIPTS_URL_PREFIX=https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts
+
+## Build argument defaults
+# Globals
+ARG ROOTFS=/root-out
+ARG REL=v3.21
+ARG ARCH=x86_64
+ARG MIRROR=http://dl-cdn.alpinelinux.org/alpine
+ARG PACKAGES=alpine-baselayout,\
 alpine-keys,\
 apk-tools,\
 busybox,\
 libc-utils
+# s6 overlay
+ARG S6_OVERLAY_RELEASES_URL_PREFIX=https://github.com/just-containers/s6-overlay/releases/download
+ARG S6_OVERLAY_VERSION="3.2.0.2"
+ARG S6_OVERLAY_ARCH=${ARCH}
+# Package versions
+ARG MODS_VERSION="v3"
+ARG PKG_INST_VERSION="v1"
+ARG LSIOWN_VERSION="v1"
+ARG WITHCONTENV_VERSION="v1"
+
+
+# RootFS stage
+FROM alpine:3.20 AS rootfs-stage
+
+# import global arguments
+ARG ROOTFS
+ARG REL
+ARG ARCH
+ARG MIRROR
+ARG PACKAGES
+
+# import s6 overlay arguments
+ARG S6_OVERLAY_RELEASES_URL_PREFIX
+ARG S6_OVERLAY_VERSION
+ARG S6_OVERLAY_ARCH
+
 
 # install packages
 RUN \
@@ -21,56 +74,79 @@ RUN \
 
 # build rootfs
 RUN \
-  mkdir -p "$ROOTFS/etc/apk" && \
+  mkdir -p "${ROOTFS}/etc/apk" && \
   { \
-    echo "$MIRROR/$REL/main"; \
-    echo "$MIRROR/$REL/community"; \
-  } > "$ROOTFS/etc/apk/repositories" && \
-  apk --root "$ROOTFS" --no-cache --keys-dir /etc/apk/keys add --arch $ARCH --initdb ${PACKAGES//,/ } && \
-  sed -i -e 's/^root::/root:!:/' /root-out/etc/shadow
-
-# set version for s6 overlay
-ARG S6_OVERLAY_VERSION="3.2.0.2"
-ARG S6_OVERLAY_ARCH="x86_64"
+    echo "${MIRROR}/${REL}/main"; \
+    echo "${MIRROR}/${REL}/community"; \
+  } > "${ROOTFS}/etc/apk/repositories" && \
+  apk --root "${ROOTFS}" --no-cache --keys-dir /etc/apk/keys add --arch $ARCH --initdb ${PACKAGES//,/ } && \
+  sed -i -e 's/^root::/root:!:/' ${ROOTFS}/etc/shadow
 
 # add s6 overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-noarch.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-noarch.tar.xz
+
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz
 
 # add s6 optional symlinks
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && unlink /root-out/usr/bin/with-contenv
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && unlink ${ROOTFS}/usr/bin/with-contenv
+
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz
+
 
 # Runtime stage
 FROM scratch
-COPY --from=rootfs-stage /root-out/ /
-ARG BUILD_DATE
-ARG VERSION
-ARG MODS_VERSION="v3"
-ARG PKG_INST_VERSION="v1"
-ARG LSIOWN_VERSION="v1"
-ARG WITHCONTENV_VERSION="v1"
-LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="TheLamer"
 
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/with-contenv.${WITHCONTENV_VERSION}" "/usr/bin/with-contenv"
+# import Runtime stage label arguments
+ARG RUNTIME_LABEL_BUILD_VERSION
+ARG RUNTIME_LABEL_MAINTAINER
+
+# import global arguments
+ARG ROOTFS
+
+# import Package version arguments
+ARG MODS_VERSION
+ARG PKG_INST_VERSION
+ARG LSIOWN_VERSION
+ARG WITHCONTENV_VERSION
+
+# import runtime stage arguments
+ARG RUNTIME_ROOT_HOME
+ARG RUNTIME_ROOT_TERM
+ARG RUNTIME_ABC_HOME
+ARG RUNTIME_ABC_SHELL
+ARG RUNTIME_ABC_GROUP
+ARG RUNTIME_ABC_GID
+ARG RUNTIME_ABC_UID
+ARG RUNTIME_S6_CMD_WAIT_FOR_SERVICES_MAXTIME
+ARG RUNTIME_S6_VERBOSITY
+ARG RUNTIME_S6_STAGE2_HOOK
+ARG RUNTIME_PS1
+ARG RUNTIME_VIRTUAL_ENV
+ARG RUNTIME_MOD_SCRIPTS_URL_PREFIX
+
+LABEL build_version="${RUNTIME_LABEL_BUILD_VERSION}"
+LABEL maintainer="${RUNTIME_LABEL_MAINTAINER}"
+
+COPY --from=rootfs-stage ${ROOTFS} /
+
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/docker-mods.${MODS_VERSION}" "${RUNTIME_S6_STAGE2_HOOK}"
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/with-contenv.${WITHCONTENV_VERSION}" "/usr/bin/with-contenv"
 
 # environment variables
-ENV PS1="$(whoami)@$(hostname):$(pwd)\\$ " \
-  HOME="/root" \
-  TERM="xterm" \
-  S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0" \
-  S6_VERBOSITY=1 \
-  S6_STAGE2_HOOK=/docker-mods \
-  VIRTUAL_ENV=/lsiopy \
-  PATH="/lsiopy/bin:$PATH"
+ENV PS1=${RUNTIME_PS1} \
+  HOME=${RUNTIME_ROOT_HOME} \
+  TERM=${RUNTIME_ROOT_TERM} \
+  S6_CMD_WAIT_FOR_SERVICES_MAXTIME=${RUNTIME_S6_CMD_WAIT_FOR_SERVICES_MAXTIME} \
+  S6_VERBOSITY=${RUNTIME_S6_VERBOSITY} \
+  S6_STAGE2_HOOK=${RUNTIME_S6_STAGE2_HOOK} \
+  VIRTUAL_ENV=${RUNTIME_VIRTUAL_ENV} \
+  PATH="${RUNTIME_VIRTUAL_ENV}/bin:${PATH}"
 
 RUN \
   echo "**** install runtime packages ****" && \
@@ -88,14 +164,14 @@ RUN \
     shadow \
     tzdata && \
   echo "**** create abc user and make our folders ****" && \
-  groupmod -g 1000 users && \
-  useradd -u 911 -U -d /config -s /bin/false abc && \
-  usermod -G users abc && \
+  groupmod -g ${RUNTIME_ABC_GID} ${RUNTIME_ABC_GROUP} && \
+  useradd -u ${RUNTIME_ABC_UID} -U -d ${RUNTIME_ABC_HOME} -s ${RUNTIME_ABC_SHELL} abc && \
+  usermod -G ${RUNTIME_ABC_GROUP} abc && \
   mkdir -p \
     /app \
-    /config \
+    ${RUNTIME_ABC_HOME} \
     /defaults \
-    /lsiopy && \
+    ${RUNTIME_VIRTUAL_ENV} && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,17 +1,70 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.20 AS rootfs-stage
+## Build arguments provided via cli arguments
+ARG VERSION
+ARG BUILD_DATE
 
-# environment
-ENV ROOTFS=/root-out
-ENV REL=v3.21
-ENV ARCH=aarch64
-ENV MIRROR=http://dl-cdn.alpinelinux.org/alpine
-ENV PACKAGES=alpine-baselayout,\
+## Runtime stage defaults
+# Labels
+ARG RUNTIME_LABEL_BUILD_VERSION="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+ARG RUNTIME_LABEL_MAINTAINER="TheLamer"
+# User: root
+ARG RUNTIME_ROOT_HOME="/root"
+ARG RUNTIME_ROOT_TERM="xterm"
+# User: abc
+ARG RUNTIME_ABC_HOME=/config
+ARG RUNTIME_ABC_SHELL=/bin/false
+ARG RUNTIME_ABC_GROUP=users
+ARG RUNTIME_ABC_GID=1000
+ARG RUNTIME_ABC_UID=911
+# Shell prompt
+ARG RUNTIME_PS1="$(whoami)@$(hostname):$(pwd)\\$ "
+# s6 overlay
+ARG RUNTIME_S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0"
+ARG RUNTIME_S6_VERBOSITY=1
+ARG RUNTIME_S6_STAGE2_HOOK=/docker-mods
+# Virtual environment location of lsiopy
+ARG RUNTIME_VIRTUAL_ENV=/lsiopy
+# mod-scripts URL
+ARG RUNTIME_MOD_SCRIPTS_URL_PREFIX=https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts
+
+## Build argument defaults
+# Globals
+ARG ROOTFS=/root-out
+ARG REL=v3.21
+ARG ARCH=aarch64
+ARG MIRROR=http://dl-cdn.alpinelinux.org/alpine
+ARG PACKAGES=alpine-baselayout,\
 alpine-keys,\
 apk-tools,\
 busybox,\
 libc-utils
+# s6 overlay
+ARG S6_OVERLAY_RELEASES_URL_PREFIX=https://github.com/just-containers/s6-overlay/releases/download
+ARG S6_OVERLAY_VERSION="3.2.0.2"
+ARG S6_OVERLAY_ARCH=${ARCH}
+# Package versions
+ARG MODS_VERSION="v3"
+ARG PKG_INST_VERSION="v1"
+ARG LSIOWN_VERSION="v1"
+ARG WITHCONTENV_VERSION="v1"
+
+
+# RootFS stage
+FROM alpine:3.20 AS rootfs-stage
+
+# import global arguments
+ARG ROOTFS
+ARG REL
+ARG ARCH
+ARG MIRROR
+ARG PACKAGES
+
+# import s6 overlay arguments
+ARG S6_OVERLAY_RELEASES_URL_PREFIX
+ARG S6_OVERLAY_VERSION
+ARG S6_OVERLAY_ARCH
+
 
 # install packages
 RUN \
@@ -21,56 +74,79 @@ RUN \
 
 # build rootfs
 RUN \
-  mkdir -p "$ROOTFS/etc/apk" && \
+  mkdir -p "${ROOTFS}/etc/apk" && \
   { \
-    echo "$MIRROR/$REL/main"; \
-    echo "$MIRROR/$REL/community"; \
-  } > "$ROOTFS/etc/apk/repositories" && \
-  apk --root "$ROOTFS" --no-cache --keys-dir /etc/apk/keys add --arch $ARCH --initdb ${PACKAGES//,/ } && \
-  sed -i -e 's/^root::/root:!:/' /root-out/etc/shadow
-
-# set version for s6 overlay
-ARG S6_OVERLAY_VERSION="3.2.0.2"
-ARG S6_OVERLAY_ARCH="aarch64"
+    echo "${MIRROR}/${REL}/main"; \
+    echo "${MIRROR}/${REL}/community"; \
+  } > "${ROOTFS}/etc/apk/repositories" && \
+  apk --root "${ROOTFS}" --no-cache --keys-dir /etc/apk/keys add --arch $ARCH --initdb ${PACKAGES//,/ } && \
+  sed -i -e 's/^root::/root:!:/' ${ROOTFS}/etc/shadow
 
 # add s6 overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-noarch.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-noarch.tar.xz
+
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.xz
 
 # add s6 optional symlinks
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && unlink /root-out/usr/bin/with-contenv
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz /tmp
-RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && unlink ${ROOTFS}/usr/bin/with-contenv
+
+ADD ${S6_OVERLAY_RELEASES_URL_PREFIX}/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz /tmp
+RUN tar -C ${ROOTFS} -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz
+
 
 # Runtime stage
 FROM scratch
-COPY --from=rootfs-stage /root-out/ /
-ARG BUILD_DATE
-ARG VERSION
-ARG MODS_VERSION="v3"
-ARG PKG_INST_VERSION="v1"
-ARG LSIOWN_VERSION="v1"
-ARG WITHCONTENV_VERSION="v1"
-LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="TheLamer"
 
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.${MODS_VERSION}" "/docker-mods"
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
-ADD --chmod=755 "https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/with-contenv.${WITHCONTENV_VERSION}" "/usr/bin/with-contenv"
+# import Runtime stage label arguments
+ARG RUNTIME_LABEL_BUILD_VERSION
+ARG RUNTIME_LABEL_MAINTAINER
+
+# import global arguments
+ARG ROOTFS
+
+# import Package version arguments
+ARG MODS_VERSION
+ARG PKG_INST_VERSION
+ARG LSIOWN_VERSION
+ARG WITHCONTENV_VERSION
+
+# import runtime stage arguments
+ARG RUNTIME_ROOT_HOME
+ARG RUNTIME_ROOT_TERM
+ARG RUNTIME_ABC_HOME
+ARG RUNTIME_ABC_SHELL
+ARG RUNTIME_ABC_GROUP
+ARG RUNTIME_ABC_GID
+ARG RUNTIME_ABC_UID
+ARG RUNTIME_S6_CMD_WAIT_FOR_SERVICES_MAXTIME
+ARG RUNTIME_S6_VERBOSITY
+ARG RUNTIME_S6_STAGE2_HOOK
+ARG RUNTIME_PS1
+ARG RUNTIME_VIRTUAL_ENV
+ARG RUNTIME_MOD_SCRIPTS_URL_PREFIX
+
+LABEL build_version="${RUNTIME_LABEL_BUILD_VERSION}"
+LABEL maintainer="${RUNTIME_LABEL_MAINTAINER}"
+
+COPY --from=rootfs-stage ${ROOTFS} /
+
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/docker-mods.${MODS_VERSION}" "${RUNTIME_S6_STAGE2_HOOK}"
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/package-install.${PKG_INST_VERSION}" "/etc/s6-overlay/s6-rc.d/init-mods-package-install/run"
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/lsiown.${LSIOWN_VERSION}" "/usr/bin/lsiown"
+ADD --chmod=755 "${RUNTIME_MOD_SCRIPTS_URL_PREFIX}/with-contenv.${WITHCONTENV_VERSION}" "/usr/bin/with-contenv"
 
 # environment variables
-ENV PS1="$(whoami)@$(hostname):$(pwd)\\$ " \
-  HOME="/root" \
-  TERM="xterm" \
-  S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0" \
-  S6_VERBOSITY=1 \
-  S6_STAGE2_HOOK=/docker-mods \
-  VIRTUAL_ENV=/lsiopy \
-  PATH="/lsiopy/bin:$PATH"
+ENV PS1=${RUNTIME_PS1} \
+  HOME=${RUNTIME_ROOT_HOME} \
+  TERM=${RUNTIME_ROOT_TERM} \
+  S6_CMD_WAIT_FOR_SERVICES_MAXTIME=${RUNTIME_S6_CMD_WAIT_FOR_SERVICES_MAXTIME} \
+  S6_VERBOSITY=${RUNTIME_S6_VERBOSITY} \
+  S6_STAGE2_HOOK=${RUNTIME_S6_STAGE2_HOOK} \
+  VIRTUAL_ENV=${RUNTIME_VIRTUAL_ENV} \
+  PATH="${RUNTIME_VIRTUAL_ENV}/bin:${PATH}"
 
 RUN \
   echo "**** install runtime packages ****" && \
@@ -88,14 +164,14 @@ RUN \
     shadow \
     tzdata && \
   echo "**** create abc user and make our folders ****" && \
-  groupmod -g 1000 users && \
-  useradd -u 911 -U -d /config -s /bin/false abc && \
-  usermod -G users abc && \
+  groupmod -g ${RUNTIME_ABC_GID} ${RUNTIME_ABC_GROUP} && \
+  useradd -u ${RUNTIME_ABC_UID} -U -d ${RUNTIME_ABC_HOME} -s ${RUNTIME_ABC_SHELL} abc && \
+  usermod -G ${RUNTIME_ABC_GROUP} abc && \
   mkdir -p \
     /app \
-    /config \
+    ${RUNTIME_ABC_HOME} \
     /defaults \
-    /lsiopy && \
+    ${RUNTIME_VIRTUAL_ENV} && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This PR puts **all** image configuration and convenience variables at the top-level of the respective Dockerfile (before any stage) as `ARG <key>[=<value>]` instructions. Top-level `ARG`s can be imported by following stages via `ARG <key>` (i.e., without setting a value).

See below for further details.

## Benefits of this PR and context:
Putting all "living" build arguments at the top-level makes it more convenient and less error prone to copy/paste and typos when changing values in the future, as those can now be set in one single place only and are imported into all stages which require them.

Take the current master branch for example. This line is defined in the stage `rootfs-stage`:
```Dockerfile
ENV ROOTFS=/root-out
```

However, a couple lines later, `/root-out` is explicitly stated again:
```Dockerfile
sed -i -e 's/^root::/root:!:/' /root-out/etc/shadow
```

This PR just defines `ROOTFS` at the top level and uses it throughout the whole file.

## How Has This Been Tested?
I'll just paste this log of my terminal inputs/outputs here:

### building the image from master branch
```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
```
```
$ git show --shortstat
commit d9e9c8a664eb5fe2023d2626ddf1e062461f824e (HEAD -> master, origin/master, origin/HEAD)
Author: LinuxServer-CI <ci@linuxserver.io>
Date:   Sat Mar 29 13:33:30 2025 +0000

    Bot Updating Package Versions

 1 file changed, 1 insertion(+), 1 deletion(-)
```
```
$ docker build --build-arg VERSION=master --build-arg BUILD_DATE=20220321 -t alpine-base:master .
[+] Building 5.4s (33/33) FINISHED                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 3.41kB                                                                                                             0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                          1.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:4c68376a702446fc3c79af22de146a148bc3367e73c25a5803d453b6b3f722fb                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                                     0.5s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 107B                                                                                                                  0.0s
 => [stage-1 5/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/with-contenv.v1 /usr/bin/with-contenv      0.3s
 => [rootfs-stage  1/11] FROM docker.io/library/alpine:3.20@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f                0.0s
 => [stage-1 4/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.v1 /usr/bin/lsiown                  0.3s
 => [rootfs-stage  8/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-noarch.tar.xz /tmp       0.9s
 => [internal] load build context                                                                                                                  0.1s
 => => transferring context: 6.69kB                                                                                                                0.1s
 => [stage-1 3/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.v1 /etc/s6-overlay/s6-rc.  0.3s
 => [stage-1 2/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.v3 /docker-mods                0.3s
 => [rootfs-stage  6/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-x86_64.tar.xz /tmp                0.9s
 => [rootfs-stage 10/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-arch.tar.xz /tmp         0.9s
 => [rootfs-stage  4/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-noarch.tar.xz /tmp                0.9s
 => CACHED [rootfs-stage  2/11] RUN   apk add --no-cache     bash     xz                                                                           0.0s
 => CACHED [rootfs-stage  3/11] RUN   mkdir -p "/root-out/etc/apk" &&   {     echo "http://dl-cdn.alpinelinux.org/alpine/v3.21/main";     echo "h  0.0s
 => CACHED [rootfs-stage  4/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-noarch.tar.xz /tmp         0.0s
 => CACHED [rootfs-stage  5/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-noarch.tar.xz                                                           0.0s
 => CACHED [rootfs-stage  6/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-x86_64.tar.xz /tmp         0.0s
 => CACHED [rootfs-stage  7/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-x86_64.tar.xz                                                           0.0s
 => CACHED [rootfs-stage  8/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-noarch.tar.xz /t  0.0s
 => CACHED [rootfs-stage  9/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && unlink /root-out/usr/bin/with-contenv         0.0s
 => CACHED [rootfs-stage 10/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-arch.tar.xz /tmp  0.0s
 => CACHED [rootfs-stage 11/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz                                                    0.0s
 => CACHED [stage-1 1/7] COPY --from=rootfs-stage /root-out/ /                                                                                     0.0s
 => CACHED [stage-1 2/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/docker-mods.v3 /docker-mods         0.0s
 => CACHED [stage-1 3/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/package-install.v1 /etc/s6-overlay  0.0s
 => CACHED [stage-1 4/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/lsiown.v1 /usr/bin/lsiown           0.0s
 => CACHED [stage-1 5/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/mod-scripts/with-contenv.v1 /usr/bin/with-cont  0.0s
 => [stage-1 6/7] RUN   echo "**** install runtime packages ****" &&   apk add --no-cache     alpine-release     bash     ca-certificates     cat  2.3s
 => [stage-1 7/7] COPY root/ /                                                                                                                     0.1s
 => exporting to image                                                                                                                             0.2s
 => => exporting layers                                                                                                                            0.2s
 => => writing image sha256:9edc053f941cd6e829c40f17b413be9e959b433d1f457eef12014c38981ae4b1                                                       0.0s
 => => naming to docker.io/library/alpine-base:master
```
```
$ docker inspect alpine-base:master | jq '.[0].Config'
{
  "Hostname": "",
  "Domainname": "",
  "User": "",
  "AttachStdin": false,
  "AttachStdout": false,
  "AttachStderr": false,
  "Tty": false,
  "OpenStdin": false,
  "StdinOnce": false,
  "Env": [
    "PATH=/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "PS1=$(whoami)@$(hostname):$(pwd)\\$ ",
    "HOME=/root",
    "TERM=xterm",
    "S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0",
    "S6_VERBOSITY=1",
    "S6_STAGE2_HOOK=/docker-mods",
    "VIRTUAL_ENV=/lsiopy"
  ],
  "Cmd": null,
  "Image": "",
  "Volumes": null,
  "WorkingDir": "/",
  "Entrypoint": [
    "/init"
  ],
  "OnBuild": null,
  "Labels": {
    "build_version": "Linuxserver.io version:- master Build-date:- 20220321",
    "maintainer": "TheLamer"
  }
}
```

### building the image from branch dockerfiles/reuse-build-arguments 
```
$ git checkout dockerfiles/reuse-build-arguments 
Switched to branch 'dockerfiles/reuse-build-arguments'
```
```
$ git status
On branch dockerfiles/reuse-build-arguments
nothing to commit, working tree clean
```
```
$ git show --shortstat
commit e7612f735caa8808d4295b6696146f18dd0df83b (HEAD -> dockerfiles/reuse-build-arguments, origin/dockerfiles/reuse-build-arguments)
Author: Timo Reichl <thetredev@gmail.com>
Date:   Sun Mar 30 19:03:58 2025 +0200

    Dockerfile.aarch64: Reuse build arguments
    
    Signed-off-by: Timo Reichl <thetredev@gmail.com>

 1 file changed, 127 insertions(+), 51 deletions(-)
```
```
$ docker build --build-arg VERSION="reuse-build-arguments" --build-arg BUILD_DATE=20220321 -t alpine-base:test .
[+] Building 3.7s (33/33) FINISHED                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 5.17kB                                                                                                             0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                          0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:4c68376a702446fc3c79af22de146a148bc3367e73c25a5803d453b6b3f722fb                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                                     0.1s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 107B                                                                                                                  0.0s
 => [rootfs-stage  1/11] FROM docker.io/library/alpine:3.20@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f                0.0s
 => [rootfs-stage  6/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-x86_64.tar.xz /tmp                0.5s
 => [internal] load build context                                                                                                                  0.1s
 => => transferring context: 6.69kB                                                                                                                0.1s
 => [stage-1 5/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/with-contenv.v1 /usr/bin/with-  0.1s
 => [stage-1 4/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/lsiown.v1 /usr/bin/lsiown       0.0s
 => [rootfs-stage  4/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-noarch.tar.xz /tmp                0.4s
 => [stage-1 3/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/package-install.v1 /etc/s6-ove  0.0s
 => [stage-1 2/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/docker-mods.v3 /docker-mods     0.0s
 => [rootfs-stage 10/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-arch.tar.xz /tmp         0.5s
 => [rootfs-stage  8/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-noarch.tar.xz /tmp       0.5s
 => CACHED [rootfs-stage  2/11] RUN   apk add --no-cache     bash     xz                                                                           0.0s
 => CACHED [rootfs-stage  3/11] RUN   mkdir -p "/root-out/etc/apk" &&   {     echo "http://dl-cdn.alpinelinux.org/alpine/v3.21/main";     echo "h  0.0s
 => CACHED [rootfs-stage  4/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-noarch.tar.xz /tmp         0.0s
 => CACHED [rootfs-stage  5/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-noarch.tar.xz                                                           0.0s
 => CACHED [rootfs-stage  6/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-x86_64.tar.xz /tmp         0.0s
 => CACHED [rootfs-stage  7/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-x86_64.tar.xz                                                           0.0s
 => CACHED [rootfs-stage  8/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-noarch.tar.xz /t  0.0s
 => CACHED [rootfs-stage  9/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && unlink /root-out/usr/bin/with-contenv         0.0s
 => CACHED [rootfs-stage 10/11] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-symlinks-arch.tar.xz /tmp  0.0s
 => CACHED [rootfs-stage 11/11] RUN tar -C /root-out -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz                                                    0.0s
 => CACHED [stage-1 1/7] COPY --from=rootfs-stage /root-out /                                                                                      0.0s
 => CACHED [stage-1 2/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/docker-mods.v3 /docker-  0.0s
 => CACHED [stage-1 3/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/package-install.v1 /etc  0.0s
 => CACHED [stage-1 4/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/lsiown.v1 /usr/bin/lsio  0.0s
 => CACHED [stage-1 5/7] ADD --chmod=755 https://raw.githubusercontent.com/linuxserver/docker-mods/refs/heads/mod-scripts/with-contenv.v1 /usr/bi  0.0s
 => [stage-1 6/7] RUN   echo "**** install runtime packages ****" &&   apk add --no-cache     alpine-release     bash     ca-certificates     cat  2.2s
 => [stage-1 7/7] COPY root/ /                                                                                                                     0.2s
 => exporting to image                                                                                                                             0.2s
 => => exporting layers                                                                                                                            0.2s
 => => writing image sha256:87c3f90064e99c1ef557e69bdcd0a964bd03eeb039b432a70971fb77e96e9052                                                       0.0s
 => => naming to docker.io/library/alpine-base:test                                                                                                0.0s
```
```
$ docker inspect alpine-base:test | jq '.[0].Config'
{
  "Hostname": "",
  "Domainname": "",
  "User": "",
  "AttachStdin": false,
  "AttachStdout": false,
  "AttachStderr": false,
  "Tty": false,
  "OpenStdin": false,
  "StdinOnce": false,
  "Env": [
    "PATH=/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "PS1=$(whoami)@$(hostname):$(pwd)\\$ ",
    "HOME=/root",
    "TERM=xterm",
    "S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0",
    "S6_VERBOSITY=1",
    "S6_STAGE2_HOOK=/docker-mods",
    "VIRTUAL_ENV=/lsiopy"
  ],
  "Cmd": null,
  "Image": "",
  "Volumes": null,
  "WorkingDir": "/",
  "Entrypoint": [
    "/init"
  ],
  "OnBuild": null,
  "Labels": {
    "build_version": "Linuxserver.io version:- reuse-build-arguments Build-date:- 20220321",
    "maintainer": "TheLamer"
  }
}
```

### running lscr.io/linuxserver/jenkins-builder:latest
```
$ docker pull lscr.io/linuxserver/jenkins-builder:latest && docker run --rm -v $(pwd):/tmp -e PUID=$(id -u) -e PGID=$(id -g) > /tmp/jenkins-builder.log lscr.io/linuxserver/jenkins-builder:latest && rm -rf .jenkins-external
latest: Pulling from linuxserver/jenkins-builder
Digest: sha256:7524be744450c9a07938e018448bafa89a78aa00a5ce331db409a1a26976f46b
Status: Image is up to date for lscr.io/linuxserver/jenkins-builder:latest
lscr.io/linuxserver/jenkins-builder:latest
```
```
$ cat /tmp/jenkins-builder.log
Linuxserver.io version: ecf81715-ls242
Build-date: 2025-03-27T12:58:47+00:00

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Set container_name] ******************************************************
ok: [localhost]

TASK [Set github_branch] *******************************************************
ok: [localhost]

TASK [Set UID] *****************************************************************
ok: [localhost]

TASK [Set GID] *****************************************************************
ok: [localhost]

TASK [Set noter] ***************************************************************
ok: [localhost]

TASK [Include var files for this project] **************************************
ok: [localhost] => (item=jenkins-vars.yml)
ok: [localhost] => (item=readme-vars.yml)

TASK [Add deprecation in S6] ***************************************************
skipping: [localhost]

TASK [Setup .github meta directory] ********************************************
included: github for localhost

TASK [github : Create .github directories] *************************************
ok: [localhost] => (item=.github/ISSUE_TEMPLATE)
ok: [localhost] => (item=.github/workflows)

TASK [github : Populate Github workflows] **************************************
changed: [localhost] => (item=call_issue_pr_tracker.yml)
changed: [localhost] => (item=call_issues_cron.yml)
ok: [localhost] => (item=external_trigger_scheduler.yml)
ok: [localhost] => (item=external_trigger.yml)
changed: [localhost] => (item=greetings.yml)
ok: [localhost] => (item=package_trigger_scheduler.yml)
changed: [localhost] => (item=permissions.yml)

TASK [github : Populate conditional Github workflows] **************************
ok: [localhost] => (item={'file': 'package_trigger_scheduler.yml', 'when': 'custom_package_trigger != true'})
ok: [localhost] => (item={'file': 'external_trigger_scheduler.yml', 'when': 'custom_external_trigger != true'})
ok: [localhost] => (item={'file': 'external_trigger.yml', 'when': 'custom_external_trigger != true'})

TASK [github : Populate Github issue templates] ********************************
changed: [localhost] => (item=issue.bug.yml)
changed: [localhost] => (item=config.yml)
changed: [localhost] => (item=issue.feature.yml)

TASK [github : Populate Github metadata] ***************************************
changed: [localhost] => (item=CONTRIBUTING.md)
changed: [localhost] => (item=FUNDING.yml)
ok: [localhost] => (item=PULL_REQUEST_TEMPLATE.md)

TASK [Generate documentation] **************************************************
included: documentation for localhost

TASK [documentation : Create Jenkins external directories] *********************
changed: [localhost]

TASK [documentation : Template Unraid template] ********************************
skipping: [localhost]

TASK [documentation : Template MkDocs page] ************************************
changed: [localhost]

TASK [documentation : Template lite README] ************************************
changed: [localhost]

TASK [documentation : Template README] *****************************************
ok: [localhost]

TASK [Generate Repository] *****************************************************
included: repository for localhost

TASK [repository : Create Root directory for donation] *************************
skipping: [localhost]

TASK [repository : Populate donation file] *************************************
skipping: [localhost]

TASK [repository : Populate Repository files] **********************************
changed: [localhost] => (item=.editorconfig)
ok: [localhost] => (item=Jenkinsfile)
ok: [localhost] => (item=LICENSE)

PLAY RECAP *********************************************************************
localhost                  : ok=20   changed=7    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
```

Rinse and repeat for `Dockerfile.aarch64`.

<!--- Include details of your testing environment, and the tests you ran to -->
### Testing environment
```
$ id
uid=1000(user) gid=1000(user) groups=1000(user),27(sudo),995(docker)
```
```
$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
```
$ uname -a
Linux docker-dev 6.12.12-zabbly+ #debian12 SMP PREEMPT_DYNAMIC Sun Feb  2 11:29:26 UTC 2025 x86_64 GNU/Linux
```
```
$ docker version
Client: Docker Engine - Community
 Version:           27.5.1
 API version:       1.47
 Go version:        go1.22.11
 Git commit:        9f9e405
 Built:             Wed Jan 22 13:41:17 2025
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          27.5.1
  API version:      1.47 (minimum version 1.24)
  Go version:       go1.22.11
  Git commit:       4c9b3b0
  Built:            Wed Jan 22 13:41:17 2025
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.25
  GitCommit:        bcc810d6b9066471b0b6fa75f557a15a1cbf31bb
 runc:
  Version:          1.2.4
  GitCommit:        v1.2.4-0-g6c52b3f
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```
```
$ docker info
Client: Docker Engine - Community
 Version:    27.5.1
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.20.0
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  v2.32.4
    Path:     /usr/libexec/docker/cli-plugins/docker-compose

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 12
 Server Version: 27.5.1
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: bcc810d6b9066471b0b6fa75f557a15a1cbf31bb
 runc version: v1.2.4-0-g6c52b3f
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.12.12-zabbly+
 Operating System: Debian GNU/Linux 12 (bookworm)
 OSType: linux
 Architecture: x86_64
 CPUs: 4
 Total Memory: 3.804GiB
 Name: docker-dev
 ID: d564d82b-4574-4beb-a553-dfd5bffbe41b
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Registry Mirrors:
  https://docker-hub.infra.incus.thetre.dev/
 Live Restore Enabled: false
```
## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
N/A
